### PR TITLE
fix: show checklists moved into folders in sidebar

### DIFF
--- a/web/lib/sidebar.js
+++ b/web/lib/sidebar.js
@@ -237,7 +237,9 @@ function renderSidebar(focusDir = '', modifiedPaths) {
             return;
         }
 
-        if (isChecklist(toFilename(path))) {
+        // Root-level checklists are rendered in Step 0 (Lists group).
+        // Checklists inside folders must still appear under their parent node.
+        if (isChecklist(toFilename(path)) && toRootPath(path) === '/') {
             return;
         }
 


### PR DESCRIPTION
## Problem

When a checklist file (`Shop.md`, `Read.md`, `Watch.md`, or any `_.md` file) is moved into a folder via the sidebar right-click → Move menu, it disappears from the sidebar entirely — even after a full page reload.

## Root cause

In `renderSidebar()` (`sidebar.js`), files are rendered in two steps:

1. **Step 0 (Lists group)** — renders root-level checklists. Skips any checklist where `toRootPath(path) !== "/"`.
2. **Second pass** — renders all other `.md` files. Skips any file where `isChecklist(toFilename(path))` is true.

When a checklist is moved into a folder (e.g. `/New Folder/Shop.md`), it fails both checks:
- Step 0 skips it because it is no longer at root.
- The second pass skips it because it is still recognised as a checklist.

The result is that the file is present on disk (OPFS DevTools confirm it) but never added to any `TreeNode`, so it never appears in the sidebar.

Closes #18.

## Fix

In the second pass, only skip checklists that are at root — those are already handled by Step 0. Checklists inside folders should fall through to the second pass and be attached to their parent folder node like any other file.

```js
// Before
if (isChecklist(toFilename(path))) {
    return;
}

// After
// Root-level checklists are rendered in Step 0 (Lists group).
// Checklists inside folders must still appear under their parent node.
if (isChecklist(toFilename(path)) && toRootPath(path) === "/") {
    return;
}
```

## Testing

1. Open https://app.files.md in Chrome (OPFS, no local folder).
2. Create a folder `Test`.
3. Create a `Shop` checklist at root and add an item.
4. Right-click `Shop` → Move → `Test`.
5. `Shop` now appears under `Test` in the sidebar. ✅
6. Hard-refresh — `Shop` still appears under `Test`. ✅