### PR TITLE
fix: panic handler logs wrong variable

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -95,7 +95,7 @@ func main() {
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error("Bot panic", "update", update, "err", err, "stacktrace", string(debug.Stack()))
+					slog.Error("Bot panic", "update", update, "err", r, "stacktrace", string(debug.Stack()))
 				}
 			}()
 


### PR DESCRIPTION
The panic recovery in the main dispatch loop logs `err` instead of `r`.

`err` here is just a leftover from main's scope — by the time a panic fires, it's either nil or something stale from a completely different operation. Not super helpful when you're debugging a crash at 2am.

The supervisor function right below already does this correctly. This just makes the main loop match.

`cmd/server/server.go:98`
  ```diff
- slog.Error("Bot panic", "update", update, "err", err, "stacktrace", string(debug.Stack()))
+ slog.Error("Bot panic", "update", update, "err", r, "stacktrace", string(debug.Stack()))