### PR TITLE
fix: chat sends message during IME composition

### DIFF
--- a/web/chat.js
+++ b/web/chat.js
@@ -269,7 +269,7 @@ async function toggleChatMessage(timestamp, text, done) {
 
 function initChat() {
     chatInput.addEventListener('keydown', async function (e) {
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
             e.preventDefault();
             await sendToChat();
             autoResize();


### PR DESCRIPTION
Added `!e.isComposing` check to the Enter handler in `initChat()`. When an IME
  is active, `isComposing` is `true` and we skip the send. Once the user finalizes
  their input, the next Enter sends normally.

  No impact on non-IME users — `isComposing` is `false` by default.

  `web/chat.js:272`
  ```diff
  - if (e.key === 'Enter' && !e.shiftKey) {
  + if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
 ```
  Fixes #27