### PR TITLE
Fix dead code in notMarkdown() parser

### DIFF
--- a/server/pkg/txt/md.go
+++ b/server/pkg/txt/md.go
@@ -416,9 +416,6 @@ func notMarkdown() parser {
 				return []result{{input[:i], input[i:]}}
 			}
 		}
-		if len(input) > 0 && (input[len(input)-1] == '*' || input[len(input)-1] != '_' || input[len(input)-1] != '`') {
-			return []result{{input, ""}}
-		}
 		if len(input) > 0 {
 			return []result{{input, ""}}
 		}


### PR DESCRIPTION
## Summary
- Remove dead code block in `notMarkdown()` parser in `server/pkg/txt/md.go`

## Problem
The condition on line 419:
```go
if len(input) > 0 && (input[len(input)-1] == '*' || input[len(input)-1] != '_' || input[len(input)-1] != '`') {
```

`input[len(input)-1] != '_' || input[len(input)-1] != '`'` is **always true** for any character (a char cannot be both `_` and `` ` `` simultaneously), making the entire condition equivalent to `len(input) > 0`. This is the same as the simpler check on line 422 right below it, making lines 419-421 unreachable dead code.

Additionally, the `input[len(input)-1] == '*'` check is redundant because the `for` loop above already returns early on any `*` character, so input can never end with `*` at this point.

## Fix
Remove the dead code block (lines 419-421), keeping only the simpler equivalent check.

## Test plan
- [ ] Verify existing tests pass: `go test ./server/pkg/txt/...`
- [ ] Verify the parser combinators still handle bold/italic markdown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)