### PR TITLE
Add bounds check for negative start/length in Substr

### DIFF
--- a/server/pkg/txt/str.go
+++ b/server/pkg/txt/str.go
@@ -34,6 +34,10 @@ func Lcfirst(str string) string {
 // Specifying skintone or gender of an emoji will count as 2 codepoints:
 // https://unicode.org/emoji/charts/full-emoji-modifiers.html
 func Substr(input string, start int, length int) string {
+	if start < 0 || length < 0 {
+		return ""
+	}
+
 	asRunes := []rune(input)
 	if start >= len(asRunes) {
 		return ""


### PR DESCRIPTION
## Summary
- Add early return for negative `start` or `length` in `server/pkg/txt/str.go:Substr()`

## Problem
The `Substr` function is exported but does not validate its `start` and `length` parameters for negative values. A negative `start` would cause a slice out-of-bounds panic:
```go
asRunes[-1 : -1+length] // panic: runtime error: slice bounds out of range
```

While current callers always pass `start=0`, this is an exported function that could be used from other packages.

## Fix
Add a guard clause at the top of the function:
```go
if start < 0 || length < 0 {
    return ""
}
```

## Test plan
- [x] Existing `TestSubstr` tests pass (`go test -vet=off -run TestSubstr ./server/pkg/txt/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)