### PR TITLE
Fix sidebar toggle shortcut across keyboard layouts

### DIFF
--- a/tests/sidebar.spec.js
+++ b/tests/sidebar.spec.js
@@ -70,6 +70,34 @@ test('root ctx menu: new dir creates a root-level directory', async ({page}) => 
     await expect(page.locator('#tree .tree-item:text-is("MyRootDir")')).toBeVisible();
 });
 
+test('sidebar toggle hotkey works for backquote and ISO layouts', async ({page}) => {
+    await setupSidebar(page);
+
+    await expect(page.locator('#sidebar')).toBeVisible();
+
+    await page.evaluate(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', {
+            key: '`',
+            code: 'Backquote',
+            metaKey: true,
+            bubbles: true,
+            cancelable: true,
+        }));
+    });
+    await expect(page.locator('#sidebar')).toBeHidden();
+
+    await page.evaluate(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', {
+            key: '§',
+            code: 'IntlBackslash',
+            metaKey: true,
+            bubbles: true,
+            cancelable: true,
+        }));
+    });
+    await expect(page.locator('#sidebar')).toBeVisible();
+});
+
 // --- file context menu -------------------------------------------------------
 
 test('file ctx menu: new file creates sibling in parent dir', async ({page}) => {

--- a/web/app.js
+++ b/web/app.js
@@ -246,6 +246,20 @@ function isMetaKey(event) {
     return event.metaKey || event.ctrlKey || event.altKey;
 }
 
+function isSidebarToggleShortcut(event) {
+    if (!isMetaKey(event)) {
+        return false;
+    }
+
+    // Match the physical shortcut key across ANSI/ISO keyboard layouts.
+    return event.code === 'Backquote'
+        || event.code === 'IntlBackslash'
+        || event.key === '`'
+        || event.key === '~'
+        || event.key === '§'
+        || event.key === '±';
+}
+
 async function openDir() {
     let dirHandle = null;
     try {
@@ -774,11 +788,7 @@ document.addEventListener('keydown', function(event) {
         }
         return;
     }
-    if (isMetaKey(event) && event.key === '~') {
-        event.preventDefault();
-        toggleSidebar();
-    }
-    if (isMetaKey(event) && event.key === '§') {
+    if (isSidebarToggleShortcut(event)) {
         event.preventDefault();
         toggleSidebar();
     }


### PR DESCRIPTION
**Title**

Fixes zakirullin/files.md#46 sidebar toggle shortcut across keyboard layouts

**Description**

## Summary

This fixes the sidebar toggle hotkey so it works more reliably across keyboard layouts.

Previously, the app only matched layout-specific `event.key` values like `~` and `§`. That made `Cmd+\`` / `Ctrl+\`` fragile on macOS and other non-US keyboard layouts, because the same physical key can report different `key` values depending on layout and modifier state.

## What changed

- Added a dedicated sidebar shortcut matcher in [web/app.js](/Users/harish/projects/files.md/web/app.js:249)
- Switched the sidebar toggle logic to prefer physical key detection via:
  - `event.code === 'Backquote'`
  - `event.code === 'IntlBackslash'`
- Kept a few `event.key` fallbacks such as `` ` ``, `~`, `§`, and `±`
- Added a regression test in [tests/sidebar.spec.js](/Users/harish/projects/files.md/tests/sidebar.spec.js:73) covering both:
  - US-style backquote key
  - ISO-layout sidebar toggle key

## Validation

- Passed targeted Playwright regression test for the new sidebar shortcut behavior
- Manually verified in Brave on macOS that `Cmd+\`` toggles the sidebar on and off

## Notes

This makes the app-side shortcut handling layout-agnostic. If a browser or OS intercepts `Cmd+\`` before the page receives it, that would still be outside the app’s control, but the reported Brave/macOS case now works.