### PR TITLE
feat: option to keep the line being edited unrendered in the editor

### DIFF
--- a/tests/editor.spec.js
+++ b/tests/editor.spec.js
@@ -43,11 +43,114 @@ test.afterEach(async ({}, testInfo) => {
     });
 });
 
+async function setMarkdownAndCursor(page, cursor = {line: 1, ch: 10}) {
+    await page.evaluate((cursorPos) => {
+        editor.setValue('# Heading\n**bold** text');
+        editor.setCursor(cursorPos);
+        editor.focus();
+        editor.refresh();
+    }, cursor);
+}
+
+async function getBoldTokenState(page) {
+    return await page.evaluate(() => {
+        const token = document.querySelector('#editor-container .cm-formatting-strong.hmd-hidden-token');
+        const style = token ? getComputedStyle(token) : null;
+
+        return {
+            hasRawLine: !!document.querySelector('#editor-container .hmd-raw-editing-line'),
+            hasHiddenStrongToken: !!token,
+            fontSize: style ? style.fontSize : null,
+            color: style ? style.color : null,
+        };
+    });
+}
+
 test('should load the Files.md editor', async ({page}) => {
     await expect(page).toHaveTitle('Files.md');
 
     await expect(page.locator('#sidebar')).toBeVisible();
     await expect(page.locator('#open-folder')).toBeVisible();
+});
+
+test('raw editing line preference is off by default', async ({page}) => {
+    await setMarkdownAndCursor(page);
+
+    await expect.poll(async () => {
+        const state = await getBoldTokenState(page);
+        return state.hasHiddenStrongToken;
+    }).toBe(true);
+
+    const state = await getBoldTokenState(page);
+    expect(state.hasRawLine).toBe(false);
+    expect(parseFloat(state.fontSize)).toBeLessThanOrEqual(1);
+    expect(await page.locator('#raw-editing-line-toggle').getAttribute('aria-pressed')).toBe('false');
+    expect(await page.evaluate(() => localStorage.getItem('rawEditingLine'))).toBe(null);
+    expect(await page.evaluate(() => editor.getOption('hmdRawEditingLine'))).toBe(false);
+});
+
+test('raw editing line preference toggles live and applies to both editors', async ({page}) => {
+    await setMarkdownAndCursor(page);
+    await page.click('#raw-editing-line-toggle');
+
+    await expect(page.locator('#raw-editing-line-toggle')).toHaveAttribute('aria-pressed', 'true');
+    await expect.poll(async () => {
+        return await page.evaluate(() => ({
+            stored: localStorage.getItem('rawEditingLine'),
+            editor: editor.getOption('hmdRawEditingLine'),
+            editor2: editor2.getOption('hmdRawEditingLine'),
+        }));
+    }).toEqual({stored: 'true', editor: true, editor2: true});
+
+    await expect.poll(async () => {
+        const state = await getBoldTokenState(page);
+        return state.hasRawLine;
+    }).toBe(true);
+
+    let state = await getBoldTokenState(page);
+    expect(state.hasHiddenStrongToken).toBe(true);
+    expect(parseFloat(state.fontSize)).toBeGreaterThan(5);
+    expect(state.color).not.toBe('rgba(0, 0, 0, 0)');
+
+    await page.evaluate(() => {
+        showEditor2();
+        editor2.setValue('# Split\n**bold** text');
+        editor2.setCursor({line: 1, ch: 10});
+        editor2.focus();
+        editor2.refresh();
+    });
+
+    await expect.poll(async () => {
+        return await page.evaluate(() => !!document.querySelector('#editor2-container .hmd-raw-editing-line'));
+    }).toBe(true);
+
+    await page.click('#raw-editing-line-toggle');
+    await expect(page.locator('#raw-editing-line-toggle')).toHaveAttribute('aria-pressed', 'false');
+    await expect.poll(async () => {
+        const offState = await getBoldTokenState(page);
+        return {
+            stored: await page.evaluate(() => localStorage.getItem('rawEditingLine')),
+            option: await page.evaluate(() => editor.getOption('hmdRawEditingLine')),
+            hasRawLine: offState.hasRawLine,
+        };
+    }).toEqual({stored: 'false', option: false, hasRawLine: false});
+});
+
+test('raw editing line preference persists after reload', async ({page}) => {
+    await page.click('#raw-editing-line-toggle');
+    await expect(page.locator('#raw-editing-line-toggle')).toHaveAttribute('aria-pressed', 'true');
+
+    await page.reload();
+    await page.waitForSelector('#tree', {timeout: 5000});
+    await setMarkdownAndCursor(page);
+
+    await expect.poll(async () => {
+        return await page.evaluate(() => ({
+            stored: localStorage.getItem('rawEditingLine'),
+            option: editor.getOption('hmdRawEditingLine'),
+            hasRawLine: !!document.querySelector('#editor-container .hmd-raw-editing-line'),
+        }));
+    }).toEqual({stored: 'true', option: true, hasRawLine: true});
 });
 
 test('should open markdown file via quick panel and see bold text formatting', async ({page}) => {
@@ -404,4 +507,3 @@ test('should handle partical text selection for word-wrap content', async ({page
         expect(selectionData.right).toBe(expectedSelections[i].right);
     }
 });
-

--- a/web/app.css
+++ b/web/app.css
@@ -503,6 +503,10 @@ button svg circle {
     stroke:  var(--col-tx) !important;
 }
 
+#raw-editing-line-toggle[aria-pressed="true"] svg {
+    stroke: var(--color-neo-orange) !important;
+}
+
 /* New-file icon: stroked rather than filled to match the other toolbar
    icons. SVG uses stroke="currentColor" so color drives the line color;
    nudge up 2px so it lines up with the folder/random-file icons that
@@ -903,4 +907,43 @@ pre.HyperMD-codeblock-end {
 
 .cm-formatting-task.cm-property {
     opacity: 0.6;
+}
+
+.CodeMirror pre.hmd-raw-editing-line span.hmd-hidden-token.cm-formatting-em,
+.CodeMirror pre.hmd-raw-editing-line span.hmd-hidden-token.cm-formatting-strong,
+.CodeMirror pre.hmd-raw-editing-line span.hmd-hidden-token.cm-formatting-strikethrough,
+.CodeMirror pre.hmd-raw-editing-line span.hmd-hidden-token.cm-formatting-code,
+.CodeMirror pre.hmd-raw-editing-line span.hmd-hidden-token.cm-formatting-link,
+.CodeMirror pre.hmd-raw-editing-line span.cm-url.hmd-hidden-token.cm-url {
+    color: var(--col-tx-alt) !important;
+    display: inline !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    letter-spacing: 0 !important;
+}
+
+.cm-s-hypermd-light pre.hmd-raw-editing-line span.cm-formatting-header,
+.cm-s-hypermd-light pre.hmd-raw-editing-line span.cm-formatting-quote,
+.cm-s-hypermd-light pre.hmd-raw-editing-line span.cm-hmd-escape-backslash,
+.cm-s-hypermd-light pre.hmd-raw-editing-line span.cm-hmd-list-indent {
+    color: var(--col-tx-alt) !important;
+    display: inline !important;
+    font-size: inherit !important;
+    line-height: inherit !important;
+    letter-spacing: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+.CodeMirror pre.hmd-raw-editing-line.HyperMD-codeblock .hmd-hidden-token {
+    display: inline !important;
+}
+
+.CodeMirror pre.hmd-raw-editing-line .cm-formatting-list-ul:has(+ .cm-formatting-task.hmd-hidden-token) {
+    display: inline !important;
+    width: auto !important;
+}
+
+.CodeMirror pre.hmd-raw-editing-line .cm-formatting-list-ul:has(+ .cm-formatting-task.hmd-hidden-token) + .cm-formatting-task.hmd-hidden-token {
+    margin-left: 0 !important;
 }

--- a/web/app.js
+++ b/web/app.js
@@ -8,6 +8,7 @@ const SHOP_PATH = '/Shop.md';
 const WATCH_PATH = '/Watch.md';
 const LOG_PATH = '/archive/Log.txt';
 const OPEN_CHAT_AFTER_IDLE = 60 * 60 * 1000; // ms
+const RAW_EDITING_LINE_STORAGE_KEY = 'rawEditingLine';
 
 let openChatIdleTimer = null;
 let isChat = false;
@@ -16,6 +17,8 @@ let debug = false;
 // let debug = {dir: '', file: 'File.md', loaded: false};
 
 async function init() {
+    updateRawEditingLineToggle();
+
     // Ask the browser to mark our origin as persistent so the quota
     // manager can't evict the auth cookie + localStorage under disk
     // pressure. Chrome auto-grants for installed PWAs / high-engagement
@@ -111,6 +114,42 @@ async function init() {
     await syncMediaFiles();
     log(`Files initialized in: ${(performance.now() - perf).toFixed(3)} milliseconds`);
 
+}
+
+function getRawEditingLinePreference() {
+    return localStorage.getItem(RAW_EDITING_LINE_STORAGE_KEY) === 'true';
+}
+
+function setRawEditingLinePreference(enabled) {
+    localStorage.setItem(RAW_EDITING_LINE_STORAGE_KEY, enabled ? 'true' : 'false');
+    updateRawEditingLineToggle();
+    applyRawEditingLinePreference();
+}
+
+function toggleRawEditingLinePreference() {
+    setRawEditingLinePreference(!getRawEditingLinePreference());
+}
+
+function updateRawEditingLineToggle() {
+    const button = document.getElementById('raw-editing-line-toggle');
+    if (!button) {
+        return;
+    }
+
+    const enabled = getRawEditingLinePreference();
+    button.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+    button.setAttribute('data-tooltip', enabled ? 'Raw current line: on' : 'Raw current line');
+}
+
+function applyRawEditingLinePreference() {
+    const enabled = getRawEditingLinePreference();
+    [window.editor, window.editor2].forEach(cm => {
+        if (!cm || typeof cm.setOption !== 'function') {
+            return;
+        }
+
+        cm.setOption('hmdRawEditingLine', enabled);
+    });
 }
 
 // Logic for click-handling is in click.js => isWikiLink

--- a/web/editor.js
+++ b/web/editor.js
@@ -1,3 +1,77 @@
+const RAW_EDITING_LINE_CLASS = 'hmd-raw-editing-line';
+
+function getRawEditingLinePreferenceValue() {
+    if (typeof getRawEditingLinePreference === 'function') {
+        return getRawEditingLinePreference();
+    }
+
+    return localStorage.getItem('rawEditingLine') === 'true';
+}
+
+function registerRawEditingLineOption() {
+    if (CodeMirror.defaults.hmdRawEditingLine !== undefined) {
+        return;
+    }
+
+    CodeMirror.defineOption('hmdRawEditingLine', false, function(cm, enabled) {
+        const state = cm.state.rawEditingLine || (cm.state.rawEditingLine = {
+            bound: false,
+            lineHandles: [],
+        });
+
+        state.enabled = !!enabled;
+        if (!state.update) {
+            state.update = () => updateRawEditingLine(cm);
+        }
+
+        if (state.enabled && !state.bound) {
+            cm.on('cursorActivity', state.update);
+            cm.on('changes', state.update);
+            cm.on('focus', state.update);
+            state.bound = true;
+        } else if (!state.enabled && state.bound) {
+            cm.off('cursorActivity', state.update);
+            cm.off('changes', state.update);
+            cm.off('focus', state.update);
+            state.bound = false;
+        }
+
+        state.update();
+    });
+}
+
+function updateRawEditingLine(cm) {
+    const state = cm.state.rawEditingLine;
+    if (!state) {
+        return;
+    }
+
+    state.lineHandles.forEach(lineHandle => {
+        cm.removeLineClass(lineHandle, 'text', RAW_EDITING_LINE_CLASS);
+    });
+    state.lineHandles = [];
+
+    if (!state.enabled) {
+        return;
+    }
+
+    const cursorLines = {};
+    cm.listSelections().forEach(selection => {
+        cursorLines[selection.head.line] = true;
+    });
+
+    Object.keys(cursorLines).forEach(line => {
+        const lineNo = Number(line);
+        if (lineNo < cm.firstLine() || lineNo > cm.lastLine()) {
+            return;
+        }
+
+        state.lineHandles.push(cm.addLineClass(lineNo, 'text', RAW_EDITING_LINE_CLASS));
+    });
+}
+
+registerRawEditingLineOption();
+
 function initEditor(el) {
     if (window.editor !== undefined && el.id === 'editor-textarea' ) {
         editor.off();
@@ -27,6 +101,7 @@ function initEditor(el) {
             math: true,
         },
         lineNumbers: false,
+        hmdRawEditingLine: getRawEditingLinePreferenceValue(),
         extraKeys: {
             // 'Shift-Space': 'autocomplete',
             'Cmd-[': false, 'Cmd-]': false,
@@ -52,6 +127,7 @@ function initEditor(el) {
     newEditor.setSize(null, '100%');
     newEditor.on('focus', function() {
         currentEditor = newEditor; // FIXME possible RC here? If isMessingWithCurrentEditor is hold, this would overwrite
+        currentEditor.setOption('hmdRawEditingLine', getRawEditingLinePreferenceValue());
         currentEditor.refresh(); // Cursor & hide tokens conflict if we don't call it
         closeChatModal();
         log('Focused to:', newEditor.path);

--- a/web/index.html
+++ b/web/index.html
@@ -85,6 +85,13 @@
                 <path d="M8 8H8.01M8 12H8.01M16 12H16.01M16 8H16.01M16 16H16.01M8 16H8.01" stroke-width="2.025" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
         </button>
+        <button id="raw-editing-line-toggle" data-tooltip="Raw current line" aria-label="Keep current line as raw Markdown" aria-pressed="false" onclick="toggleRawEditingLinePreference()">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 32 32">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M12 9l-7 7 7 7"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.2" d="M20 9l7 7-7 7"/>
+                <path stroke-linecap="round" stroke-width="2.2" d="M17.5 7l-3 18"/>
+            </svg>
+        </button>
     </div>
     <div id="tree">
     </div>


### PR DESCRIPTION
## Summary
When editing a markdown line, HyperMD live-renders syntax tokens (`#`, `*`, link
brackets) and reveals them only on the active line. The reporter finds the
text popping in and out of rendered mode disorienting while editing, and asks
for a way to toggle rendering, or at minimum to keep the line currently being
edited fully unrendered (raw markdown) so the text under the cursor stays
"steady." Two clarifying videos contrast files.md against vim's conceal-off

## Why this matters
Add an opt-in "raw editing line" preference rather than changing the default
look. HyperMD already exposes per-feature flags (`hmdHideToken`); the editor is
created via `HyperMD.fromTextArea` in `web/editor.js`. Introduce a boolean
preference (persisted in `localStorage`, mirroring the existing `apiUrl`
pattern in `web/app.js`) that, when enabled, sets `hmdHideToken: false` (or the
narrower per-line equivalent) so the active line keeps its raw markdown tokens

Closes #38.

## Testing
Added Playwright e2e specs in `tests/editor.spec.js` covering the new toggle. `go build ./...` and `go vet ./...` pass. The full e2e suite needs the project's Playwright harness (http-server + running server + browsers per docs/e2e-tests.md) which was not run locally.

AI was used for assistance.
