### PR TITLE
fix: horizontal table scrollbar drag selects editor text instead of scrolling

### DIFF
--- a/tests/editor.spec.js
+++ b/tests/editor.spec.js
@@ -141,6 +141,57 @@ test('should handle text selection correctly', async ({page}) => {
     }
 });
 
+test('dragging a rendered table horizontal scrollbar does not select editor text', async ({page}) => {
+    const table = [
+        '<table>',
+        '<tr><th>Alpha column</th><th>Beta column</th><th>Gamma column</th><th>Delta column</th><th>Epsilon column</th><th>Zeta column</th><th>Eta column</th><th>Theta column</th></tr>',
+        '<tr><td>Alpha cell with selectable text</td><td>Beta cell with selectable text</td><td>Gamma cell with selectable text</td><td>Delta cell with selectable text</td><td>Epsilon cell with selectable text</td><td>Zeta cell with selectable text</td><td>Eta cell with selectable text</td><td>Theta cell with selectable text</td></tr>',
+        '</table>',
+    ].join('');
+
+    await page.evaluate((content) => {
+        editor.setValue(`# Table drag\n\nNormal paragraph text remains selectable.\n\n${content}`);
+        editor.refresh();
+    }, table);
+
+    const scroller = page.locator('#editor-container .hmd-table-scroll').first();
+    await expect(scroller).toBeVisible();
+    await expect.poll(async () => {
+        return await scroller.evaluate((el) => el.scrollWidth > el.clientWidth);
+    }).toBe(true);
+
+    const tableCellUserSelect = await page.locator('#editor-container .hmd-table-scroll td').first().evaluate((el) => {
+        return window.getComputedStyle(el).userSelect;
+    });
+    expect(tableCellUserSelect).not.toBe('none');
+
+    await page.evaluate(() => editor.setCursor({line: 0, ch: 0}));
+    const box = await scroller.boundingBox();
+    expect(box).not.toBeNull();
+
+    const startX = box.x + 20;
+    const endX = box.x + box.width - 20;
+    const scrollbarY = box.y + box.height - 3;
+    const scrollBefore = await scroller.evaluate((el) => el.scrollLeft);
+
+    await page.mouse.move(startX, scrollbarY);
+    await page.mouse.down();
+    await page.mouse.move(endX, scrollbarY, {steps: 8});
+    await page.mouse.up();
+
+    await expect.poll(async () => {
+        return await scroller.evaluate((el) => el.scrollLeft);
+    }).toBeGreaterThan(scrollBefore);
+
+    await expect(page.locator('#editor-container .CodeMirror-selected')).toHaveCount(0);
+
+    await page.mouse.move(box.x + 20, box.y + 20);
+    await page.mouse.down();
+    const hasScrollingClass = await scroller.evaluate((el) => el.classList.contains('is-scrolling'));
+    await page.mouse.up();
+    expect(hasScrollingClass).toBe(false);
+});
+
 test('should handle text selection for word-wrap content', async ({page}) => {
     test.skip(!process.env.RUN_SELECTION, 'pixel-dependent; run with RUN_SELECTION=1');
     // Add some test content with various markdown elements
@@ -404,4 +455,3 @@ test('should handle partical text selection for word-wrap content', async ({page
         expect(selectionData.right).toBe(expectedSelections[i].right);
     }
 });
-

--- a/web/app.css
+++ b/web/app.css
@@ -183,20 +183,37 @@ body:has(#sidebar[style*="display: none"]):has(#editor2-container.show) #editor-
 }
 
 
-#content table, th, td {
+#content .hmd-table-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+#content .hmd-table-scroll.is-scrolling {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+}
+
+#content .hmd-table-scroll table {
+    width: max-content;
+    min-width: 100%;
+}
+
+#content table, #content th, #content td {
     border-collapse: collapse;
     border: 1px solid #878787;
 }
 
-td {
+#content td {
     text-align: center;
 }
 
-th {
+#content th {
     padding: 3px;
 }
 
-td {
+#content td {
     padding: 2px;
 }
 

--- a/web/editor.js
+++ b/web/editor.js
@@ -1,18 +1,81 @@
+function cleanupEditor(editorInstance) {
+    if (!editorInstance) return;
+
+    if (editorInstance._tableScrollObserver) {
+        editorInstance._tableScrollObserver.disconnect();
+    }
+
+    editorInstance.off();
+}
+
+function wrapRenderedTables(root) {
+    if (!root || !root.querySelectorAll) return;
+
+    root.querySelectorAll('table').forEach((table) => {
+        if (table.closest('.hmd-table-scroll')) return;
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'hmd-table-scroll';
+        table.parentNode.insertBefore(wrapper, table);
+        wrapper.appendChild(table);
+    });
+}
+
+function installTableScrollWrappers(cm) {
+    const wrapper = cm.getWrapperElement();
+
+    wrapRenderedTables(wrapper);
+
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+            mutation.addedNodes.forEach((node) => {
+                if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+                if (node.matches && node.matches('table')) {
+                    wrapRenderedTables(node.parentNode);
+                    return;
+                }
+
+                wrapRenderedTables(node);
+            });
+        });
+    });
+
+    observer.observe(wrapper, {childList: true, subtree: true});
+    cm._tableScrollObserver = observer;
+}
+
+function getHorizontalTableScrollbar(e) {
+    if (!e.target.closest) return null;
+
+    const scroller = e.target.closest('.hmd-table-scroll');
+    if (!scroller || scroller.scrollWidth <= scroller.clientWidth) return null;
+
+    const scrollbarHeight = scroller.offsetHeight - scroller.clientHeight;
+    if (scrollbarHeight <= 0) return null;
+
+    const rect = scroller.getBoundingClientRect();
+    const withinX = e.clientX >= rect.left && e.clientX <= rect.right;
+    const withinScrollbarY = e.clientY >= rect.bottom - scrollbarHeight && e.clientY <= rect.bottom;
+
+    return withinX && withinScrollbarY ? scroller : null;
+}
+
 function initEditor(el) {
     if (window.editor !== undefined && el.id === 'editor-textarea' ) {
-        editor.off();
+        cleanupEditor(editor);
         const wrapper = editor.getWrapperElement();
         if (wrapper && wrapper.parentNode) {
             wrapper.parentNode.removeChild(wrapper);
         }
 
-        editor2.off();
+        cleanupEditor(editor2);
         const wrapper2 = editor2.getWrapperElement();
         if (wrapper2 && wrapper2.parentNode) {
             wrapper2.parentNode.removeChild(wrapper2);
         }
     } else if (window.editor2 !== undefined && el.id === 'editor2-textarea') {
-        editor2.off();
+        cleanupEditor(editor2);
         const wrapper = editor2.getWrapperElement();
         if (wrapper && wrapper.parentNode) {
             wrapper.parentNode.removeChild(wrapper);
@@ -197,6 +260,19 @@ function initEditor(el) {
             })
         }
     })
+
+    installTableScrollWrappers(newEditor);
+
+    newEditor.getWrapperElement().addEventListener('mousedown', function(e) {
+        const scroller = getHorizontalTableScrollbar(e);
+        if (!scroller) return;
+
+        scroller.classList.add('is-scrolling');
+        const stopScrolling = () => scroller.classList.remove('is-scrolling');
+        window.addEventListener('mouseup', stopScrolling, {once: true});
+        window.addEventListener('blur', stopScrolling, {once: true});
+        e.stopImmediatePropagation();
+    }, true);
 
     // Auto-select/highlight title when clicking on the first line
     // TODO clear on second click


### PR DESCRIPTION
## Summary
Horizontal scrolling of a large rendered table does not work properly on
Windows 11 / Chrome. The reporter diagnosed it: dragging the horizontal
scrollbar of the table is also detected as a click/drag on the underlying
editor, so instead of scrolling the table the editor begins selecting
(highlighting) text. Middle-click scrolling and vertical scrolling both work
fine, which confirms the problem is specifically the pointer interaction with

## Why this matters
The rendered table (`#content table`/`td`/`th` in `web/app.css`) has no
dedicated horizontally scrollable wrapper, so the native scrollbar sits on the
same element the CodeMirror selection logic tracks. Wrap the rendered table in
an overflow-x scroll container and suppress text selection while the pointer is
interacting with that scrollbar region: add `user-select: none` (and the
`-webkit-`/`-moz-` prefixes for cross-browser coverage) plus

Closes #43.

## Testing
Added e2e coverage in `tests/editor.spec.js`. `go build ./...` and `go vet ./...` pass. Full Playwright e2e harness not run locally.

AI was used for assistance.
