### PR TITLE
fix: last chat line hidden behind input/toolbar on mobile (Firefox Android)

### DIFF
--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -1,5 +1,32 @@
 const {test, expect} = require('@playwright/test');
 
+async function sendChatMessage(page, text, expectedCount) {
+    await page.locator('#chat-input').fill(text);
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.message')).toHaveCount(expectedCount);
+}
+
+async function getChatVisibilityMetrics(page) {
+    return await page.evaluate(() => {
+        const chat = document.getElementById('chat');
+        const input = document.getElementById('chat-input');
+        const lastMessage = chat.querySelector('.message:last-child');
+        const chatRect = chat.getBoundingClientRect();
+        const inputRect = input.getBoundingClientRect();
+        const lastRect = lastMessage.getBoundingClientRect();
+        const style = getComputedStyle(chat);
+
+        return {
+            bottomGap: chatRect.bottom - lastRect.bottom,
+            inputGap: inputRect.top - lastRect.bottom,
+            paddingBottom: parseFloat(style.paddingBottom),
+            scrollPaddingBottom: parseFloat(style.scrollPaddingBottom),
+            scrollTop: chat.scrollTop,
+            maxScrollTop: chat.scrollHeight - chat.clientHeight,
+        };
+    });
+}
+
 test.beforeEach(async ({page}) => {
     await page.goto('/index.html');
 
@@ -39,6 +66,57 @@ test('select all in chat input selects input text, not bubbles', async ({page}) 
 
     await expect(page.locator('#chat-input')).toHaveValue('');
     await expect(page.locator('.message-content')).toHaveText('First message');
+});
+
+test('mobile chat keeps the latest message clear of the composer', async ({page}) => {
+    await page.setViewportSize({width: 900, height: 700});
+    await page.evaluate(async () => {
+        const root = await navigator.storage.getDirectory();
+        const fh = await root.getFileHandle('File.md', {create: true});
+        const w = await fh.createWritable();
+        await w.write('# File');
+        await w.close();
+        window.getTemporaryStorageDirHandle = async () => navigator.storage.getDirectory();
+    });
+    await page.evaluate(() => init(document.getElementById('editor')));
+
+    await page.click(`#tree .tree-item:has-text('chat')`);
+    await page.waitForSelector('#chat');
+
+    const desktopPaddingBottom = await page.locator('#chat').evaluate(chat =>
+        parseFloat(getComputedStyle(chat).paddingBottom));
+    expect(desktopPaddingBottom).toBe(24);
+
+    await page.setViewportSize({width: 390, height: 360});
+
+    for (let i = 1; i <= 8; i++) {
+        await sendChatMessage(page, `Mobile thought ${i}`, i);
+    }
+
+    await expect.poll(async () => {
+        const metrics = await getChatVisibilityMetrics(page);
+        return Math.round(metrics.maxScrollTop - metrics.scrollTop);
+    }).toBe(0);
+
+    let metrics = await getChatVisibilityMetrics(page);
+    expect(metrics.paddingBottom).toBeGreaterThanOrEqual(96);
+    expect(metrics.scrollPaddingBottom).toBeGreaterThanOrEqual(72);
+    expect(metrics.bottomGap).toBeGreaterThanOrEqual(88);
+    expect(metrics.inputGap).toBeGreaterThanOrEqual(88);
+
+    await page.evaluate(async () => openFile('/File.md'));
+    await page.waitForSelector('.CodeMirror');
+    await page.evaluate(async () => openChat());
+    await page.waitForSelector('#chat');
+
+    await expect.poll(async () => {
+        const metrics = await getChatVisibilityMetrics(page);
+        return Math.round(metrics.maxScrollTop - metrics.scrollTop);
+    }).toBe(0);
+
+    metrics = await getChatVisibilityMetrics(page);
+    expect(metrics.bottomGap).toBeGreaterThanOrEqual(88);
+    expect(metrics.inputGap).toBeGreaterThanOrEqual(88);
 });
 
 test('move to dir creates a new file inside that dir', async ({page}) => {

--- a/web/chat.css
+++ b/web/chat.css
@@ -7,6 +7,14 @@
     position: relative;
 }
 
+@media (max-width: 670px) {
+    #chat {
+        --chat-input-bottom-space: calc(72px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: calc(24px + var(--chat-input-bottom-space));
+        scroll-padding-bottom: var(--chat-input-bottom-space);
+    }
+}
+
 #chat-container {
     display: flex;
     flex-direction: column;

--- a/web/chat.js
+++ b/web/chat.js
@@ -279,7 +279,7 @@ function initChat() {
 
 function scrollToBottom() {
     setTimeout(function () {
-        chat.scrollTop = chat.scrollHeight;
+        chat.scrollTop = Math.max(0, chat.scrollHeight - chat.clientHeight);
     }, 100);
 }
 


### PR DESCRIPTION
## Summary
On Firefox 151 for Android 16, the most recently entered chat thought is hidden
behind the chat input / button toolbar at the bottom. The screenshot shows that
of three entered thoughts only the first two are fully visible; the third is
mostly obscured by the bottom controls. The problem persists after navigating
away to another file and back, and is independent of whether the on-screen
keyboard is shown. The owner is actively engaged on mobile support: he hid the

## Why this matters
`#chat` is `overflow-y: auto; flex: 1` and `#chat-input` is a sibling flex
child below it; on mobile the chat scroll container can scroll its last message
underneath the composer/toolbar so the final line is never reachable. Add
bottom breathing room so the last message clears the controls: give `#chat` a
`scroll-padding-bottom` (and/or a `padding-bottom`) sized to the composer
height, scoped behind a mobile `@media` query so desktop layout is unchanged,

Closes #44.

## Testing
Added e2e coverage in `tests/chat.spec.js`. `go build ./...` and `go vet ./...` pass. Full Playwright e2e harness not run locally.

AI was used for assistance.
