### PR TITLE
Add external LLM assistant and refresh the Files.md UI

### DIFF
--- a/docs/your-own-server.md
+++ b/docs/your-own-server.md
@@ -28,8 +28,46 @@ CERT_DIR=/opt/files.md
 TOKENS_DIR=/opt/files.md/tokens
 LOG_FILE=server.log
 API_URL=https://api.yourdomain.com
-APP_URL=https://app.youdomain.com
+APP_URL=https://app.yourdomain.com
 ```
+
+### Optional LLM assistant
+LLM assistant is disabled unless you configure a provider on your server. The server calls an OpenAI-compatible chat completions API and keeps the provider key out of the browser.
+
+Add placeholder values like these to `/app/.env`:
+```
+LLM_PROVIDER_BASE_URL=https://api.example.com/v1
+LLM_MODEL=<MODEL_NAME>
+LLM_API_KEY=<PROVIDER_API_KEY>
+
+# Optional timeout and limits
+LLM_TIMEOUT_SECONDS=30
+LLM_MAX_BODY_BYTES=262144
+LLM_MAX_PROMPT_CHARS=8000
+LLM_MAX_CONTEXT_BLOCKS=8
+LLM_MAX_CONTEXT_BYTES=131072
+LLM_MAX_RESPONSE_BYTES=262144
+LLM_MAX_OUTPUT_TOKENS=1024
+LLM_USER_RATE_PER_MINUTE=10
+LLM_IP_RATE_PER_MINUTE=60
+LLM_USER_CONCURRENCY=2
+LLM_USER_DAILY_QUOTA=100
+```
+
+Use your provider's real base URL, model name, and API key only in your private server environment. Prefer `https` provider URLs; use `http` only for an intentionally configured local or private gateway.
+
+Privacy behavior:
+- Ordinary chat capture still writes to local Markdown and does not call the LLM provider.
+- Only content you explicitly select or request for an assistant action is sent to the configured provider.
+- Files.md does not send whole folders, unrelated sync data, or your whole vault as background LLM context.
+- The external provider's own retention policy applies to anything you choose to send.
+
+Current LLM limitations:
+- Responses are non-streaming.
+- There is no whole-vault context or retrieval index.
+- Model output is shown as a draft until you choose to copy, insert, append to `Chat.md`, or discard it.
+- Files.md does not automatically mutate Markdown after an LLM response.
+- Files.md does not automatically create a separate AI transcript file.
 
 Deploy a systemd service:
 ```bash

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -24,10 +25,31 @@ type Config struct {
 	ServerLogFile     string `default:"/tmp/server.log" envconfig:"LOG_FILE"`
 	StorageQuotaKB    int64  `default:"1024" envconfig:"STORAGE_QUOTA_KB"` // 1MB
 	UnlimitedQuotaIDs string `envconfig:"UNLIMITED_QUOTA_IDS"`
+
+	LLMProviderBaseURL   string `envconfig:"LLM_PROVIDER_BASE_URL"`
+	LLMModel             string `envconfig:"LLM_MODEL"`
+	LLMAPIKey            string `envconfig:"LLM_API_KEY"`
+	LLMTimeoutSeconds    int    `default:"30" envconfig:"LLM_TIMEOUT_SECONDS"`
+	LLMMaxBodyBytes      int64  `default:"262144" envconfig:"LLM_MAX_BODY_BYTES"`
+	LLMMaxPromptChars    int    `default:"8000" envconfig:"LLM_MAX_PROMPT_CHARS"`
+	LLMMaxContextBlocks  int    `default:"8" envconfig:"LLM_MAX_CONTEXT_BLOCKS"`
+	LLMMaxContextBytes   int64  `default:"131072" envconfig:"LLM_MAX_CONTEXT_BYTES"`
+	LLMMaxResponseBytes  int64  `default:"262144" envconfig:"LLM_MAX_RESPONSE_BYTES"`
+	LLMMaxOutputTokens   int    `default:"1024" envconfig:"LLM_MAX_OUTPUT_TOKENS"`
+	LLMUserRatePerMinute int    `default:"10" envconfig:"LLM_USER_RATE_PER_MINUTE"`
+	LLMIPRatePerMinute   int    `default:"60" envconfig:"LLM_IP_RATE_PER_MINUTE"`
+	LLMUserConcurrency   int    `default:"2" envconfig:"LLM_USER_CONCURRENCY"`
+	LLMUserDailyQuota    int    `default:"100" envconfig:"LLM_USER_DAILY_QUOTA"`
 }
 
 func (c Config) APIHost() string { return hostOf(c.APIURL) }
 func (c Config) AppHost() string { return hostOf(c.AppURL) }
+func (c Config) LLMTimeout() time.Duration {
+	if c.LLMTimeoutSeconds <= 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(c.LLMTimeoutSeconds) * time.Second
+}
 
 func hostOf(rawURL string) string {
 	if rawURL == "" {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBotConfigLoadsLLMProviderSettings(t *testing.T) {
+	restoreEnv := clearLLMEnv(t)
+	defer restoreEnv()
+
+	t.Setenv("LLM_PROVIDER_BASE_URL", "https://llm.example.test/v1")
+	t.Setenv("LLM_MODEL", "test-model")
+	t.Setenv("LLM_API_KEY", "test-secret")
+	t.Setenv("LLM_TIMEOUT_SECONDS", "9")
+	t.Setenv("LLM_MAX_BODY_BYTES", "12345")
+	t.Setenv("LLM_MAX_PROMPT_CHARS", "123")
+	t.Setenv("LLM_MAX_CONTEXT_BLOCKS", "3")
+	t.Setenv("LLM_MAX_CONTEXT_BYTES", "456")
+	t.Setenv("LLM_MAX_RESPONSE_BYTES", "789")
+	t.Setenv("LLM_MAX_OUTPUT_TOKENS", "321")
+	t.Setenv("LLM_USER_RATE_PER_MINUTE", "2")
+	t.Setenv("LLM_IP_RATE_PER_MINUTE", "4")
+	t.Setenv("LLM_USER_CONCURRENCY", "1")
+	t.Setenv("LLM_USER_DAILY_QUOTA", "6")
+
+	origCfg := ServerCfg
+	defer func() { ServerCfg = origCfg }()
+
+	require.NoError(t, LoadBotConfig())
+	require.Equal(t, "https://llm.example.test/v1", ServerCfg.LLMProviderBaseURL)
+	require.Equal(t, "test-model", ServerCfg.LLMModel)
+	require.Equal(t, "test-secret", ServerCfg.LLMAPIKey)
+	require.Equal(t, 9*time.Second, ServerCfg.LLMTimeout())
+	require.EqualValues(t, 12345, ServerCfg.LLMMaxBodyBytes)
+	require.Equal(t, 123, ServerCfg.LLMMaxPromptChars)
+	require.Equal(t, 3, ServerCfg.LLMMaxContextBlocks)
+	require.EqualValues(t, 456, ServerCfg.LLMMaxContextBytes)
+	require.EqualValues(t, 789, ServerCfg.LLMMaxResponseBytes)
+	require.Equal(t, 321, ServerCfg.LLMMaxOutputTokens)
+	require.Equal(t, 2, ServerCfg.LLMUserRatePerMinute)
+	require.Equal(t, 4, ServerCfg.LLMIPRatePerMinute)
+	require.Equal(t, 1, ServerCfg.LLMUserConcurrency)
+	require.Equal(t, 6, ServerCfg.LLMUserDailyQuota)
+}
+
+func TestLoadBotConfigUsesLLMDefaults(t *testing.T) {
+	restoreEnv := clearLLMEnv(t)
+	defer restoreEnv()
+
+	origCfg := ServerCfg
+	defer func() { ServerCfg = origCfg }()
+
+	require.NoError(t, LoadBotConfig())
+	require.Equal(t, 30*time.Second, ServerCfg.LLMTimeout())
+	require.EqualValues(t, 256<<10, ServerCfg.LLMMaxBodyBytes)
+	require.Equal(t, 8000, ServerCfg.LLMMaxPromptChars)
+	require.Equal(t, 8, ServerCfg.LLMMaxContextBlocks)
+	require.EqualValues(t, 128<<10, ServerCfg.LLMMaxContextBytes)
+	require.EqualValues(t, 256<<10, ServerCfg.LLMMaxResponseBytes)
+	require.Equal(t, 1024, ServerCfg.LLMMaxOutputTokens)
+	require.Equal(t, 10, ServerCfg.LLMUserRatePerMinute)
+	require.Equal(t, 60, ServerCfg.LLMIPRatePerMinute)
+	require.Equal(t, 2, ServerCfg.LLMUserConcurrency)
+	require.Equal(t, 100, ServerCfg.LLMUserDailyQuota)
+}
+
+func clearLLMEnv(t *testing.T) func() {
+	t.Helper()
+
+	keys := []string{
+		"LLM_PROVIDER_BASE_URL",
+		"LLM_MODEL",
+		"LLM_API_KEY",
+		"LLM_TIMEOUT_SECONDS",
+		"LLM_MAX_BODY_BYTES",
+		"LLM_MAX_PROMPT_CHARS",
+		"LLM_MAX_CONTEXT_BLOCKS",
+		"LLM_MAX_CONTEXT_BYTES",
+		"LLM_MAX_RESPONSE_BYTES",
+		"LLM_MAX_OUTPUT_TOKENS",
+		"LLM_USER_RATE_PER_MINUTE",
+		"LLM_IP_RATE_PER_MINUTE",
+		"LLM_USER_CONCURRENCY",
+		"LLM_USER_DAILY_QUOTA",
+	}
+
+	type saved struct {
+		value string
+		ok    bool
+	}
+	orig := make(map[string]saved, len(keys))
+	for _, key := range keys {
+		value, ok := os.LookupEnv(key)
+		orig[key] = saved{value: value, ok: ok}
+		require.NoError(t, os.Unsetenv(key))
+	}
+
+	return func() {
+		for _, key := range keys {
+			if orig[key].ok {
+				_ = os.Setenv(key, orig[key].value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}
+}

--- a/server/llm/handler.go
+++ b/server/llm/handler.go
@@ -1,0 +1,592 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/zakirullin/files.md/server/config"
+)
+
+const UserIDContextKey = "userID"
+
+type Config struct {
+	ProviderBaseURL       string
+	Model                 string
+	APIKey                string
+	AppURL                string
+	Timeout               time.Duration
+	MaxBodyBytes          int64
+	MaxPromptChars        int
+	MaxContextBlocks      int
+	MaxContextBytes       int64
+	MaxResponseBytes      int64
+	MaxOutputTokens       int
+	UserRequestsPerMinute int
+	IPRequestsPerMinute   int
+	UserConcurrency       int
+	UserDailyQuota        int
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Timeout:               30 * time.Second,
+		MaxBodyBytes:          256 << 10,
+		MaxPromptChars:        8000,
+		MaxContextBlocks:      8,
+		MaxContextBytes:       128 << 10,
+		MaxResponseBytes:      256 << 10,
+		MaxOutputTokens:       1024,
+		UserRequestsPerMinute: 10,
+		IPRequestsPerMinute:   60,
+		UserConcurrency:       2,
+		UserDailyQuota:        100,
+	}
+}
+
+func FromServerConfig(c config.Config) Config {
+	cfg := DefaultConfig()
+	cfg.ProviderBaseURL = c.LLMProviderBaseURL
+	cfg.Model = c.LLMModel
+	cfg.APIKey = c.LLMAPIKey
+	cfg.AppURL = c.AppURL
+	cfg.Timeout = c.LLMTimeout()
+	cfg.MaxBodyBytes = c.LLMMaxBodyBytes
+	cfg.MaxPromptChars = c.LLMMaxPromptChars
+	cfg.MaxContextBlocks = c.LLMMaxContextBlocks
+	cfg.MaxContextBytes = c.LLMMaxContextBytes
+	cfg.MaxResponseBytes = c.LLMMaxResponseBytes
+	cfg.MaxOutputTokens = c.LLMMaxOutputTokens
+	cfg.UserRequestsPerMinute = c.LLMUserRatePerMinute
+	cfg.IPRequestsPerMinute = c.LLMIPRatePerMinute
+	cfg.UserConcurrency = c.LLMUserConcurrency
+	cfg.UserDailyQuota = c.LLMUserDailyQuota
+	return cfg.withDefaults()
+}
+
+func (c Config) withDefaults() Config {
+	defaults := DefaultConfig()
+	if c.Timeout <= 0 {
+		c.Timeout = defaults.Timeout
+	}
+	if c.MaxBodyBytes <= 0 {
+		c.MaxBodyBytes = defaults.MaxBodyBytes
+	}
+	if c.MaxPromptChars <= 0 {
+		c.MaxPromptChars = defaults.MaxPromptChars
+	}
+	if c.MaxContextBlocks <= 0 {
+		c.MaxContextBlocks = defaults.MaxContextBlocks
+	}
+	if c.MaxContextBytes <= 0 {
+		c.MaxContextBytes = defaults.MaxContextBytes
+	}
+	if c.MaxResponseBytes <= 0 {
+		c.MaxResponseBytes = defaults.MaxResponseBytes
+	}
+	if c.MaxOutputTokens <= 0 {
+		c.MaxOutputTokens = defaults.MaxOutputTokens
+	}
+	if c.UserRequestsPerMinute <= 0 {
+		c.UserRequestsPerMinute = defaults.UserRequestsPerMinute
+	}
+	if c.IPRequestsPerMinute <= 0 {
+		c.IPRequestsPerMinute = defaults.IPRequestsPerMinute
+	}
+	if c.UserConcurrency <= 0 {
+		c.UserConcurrency = defaults.UserConcurrency
+	}
+	if c.UserDailyQuota <= 0 {
+		c.UserDailyQuota = defaults.UserDailyQuota
+	}
+	return c
+}
+
+type ContextBlock struct {
+	Source string `json:"source"`
+	Label  string `json:"label,omitempty"`
+	Path   string `json:"path,omitempty"`
+	Text   string `json:"text"`
+}
+
+type ChatRequest struct {
+	Action          string
+	Prompt          string
+	Contexts        []ContextBlock
+	MaxOutputTokens int
+	ProviderBaseURL string
+}
+
+type ChatResponse struct {
+	Model string
+	Text  string
+}
+
+type Provider interface {
+	Chat(context.Context, ChatRequest) (ChatResponse, error)
+}
+
+type Handler struct {
+	cfg       Config
+	provider  Provider
+	now       func() time.Time
+	requestID func() string
+	limits    *limits
+}
+
+type Option func(*Handler)
+
+func WithProvider(provider Provider) Option {
+	return func(h *Handler) {
+		h.provider = provider
+	}
+}
+
+func WithNow(now func() time.Time) Option {
+	return func(h *Handler) {
+		h.now = now
+	}
+}
+
+func WithRequestID(requestID func() string) Option {
+	return func(h *Handler) {
+		h.requestID = requestID
+	}
+}
+
+func NewHandler(cfg Config, opts ...Option) *Handler {
+	cfg = cfg.withDefaults()
+	h := &Handler{
+		cfg:       cfg,
+		now:       time.Now,
+		requestID: newRequestID,
+		limits:    newLimits(),
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+type statusResponse struct {
+	Status    string `json:"status"`
+	Available bool   `json:"available"`
+	Model     string `json:"model,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type chatResponse struct {
+	Status    string `json:"status"`
+	RequestID string `json:"requestId"`
+	Model     string `json:"model"`
+	Text      string `json:"text"`
+}
+
+type errorResponse struct {
+	Status  string `json:"status"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (h *Handler) Status(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAuthenticated(w, r) {
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid LLM status request.")
+		return
+	}
+
+	reason := h.unavailableReason()
+	if reason != "" {
+		writeJSON(w, http.StatusOK, statusResponse{
+			Status:    "ok",
+			Available: false,
+			Reason:    reason,
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, statusResponse{
+		Status:    "ok",
+		Available: true,
+		Model:     h.cfg.Model,
+	})
+}
+
+type chatPayload struct {
+	Action          string         `json:"action"`
+	Prompt          string         `json:"prompt"`
+	Contexts        []ContextBlock `json:"contexts"`
+	ClientRequestID string         `json:"clientRequestId,omitempty"`
+}
+
+func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
+	userID, ok := h.userID(w, r)
+	if !ok {
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid LLM chat request.")
+		return
+	}
+	if !h.trustedOrigin(r) {
+		writeError(w, http.StatusForbidden, "forbidden", "The request origin is not allowed.")
+		return
+	}
+	if reason := h.unavailableReason(); reason != "" {
+		writeError(w, http.StatusBadGateway, "unavailable", "LLM assistance is not available.")
+		return
+	}
+
+	payload, ok := h.decodePayload(w, r)
+	if !ok {
+		return
+	}
+	if !h.validatePayload(w, payload) {
+		return
+	}
+
+	release, ok := h.limits.reserve(userID, clientIP(r), h.now(), h.cfg)
+	if !ok {
+		writeError(w, http.StatusTooManyRequests, "rate_limited", "LLM request limit reached.")
+		return
+	}
+	defer release()
+
+	provider, err := h.providerClient()
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "provider_error", "LLM provider request failed.")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), h.cfg.Timeout)
+	defer cancel()
+
+	resp, err := provider.Chat(ctx, ChatRequest{
+		Action:          payload.Action,
+		Prompt:          payload.Prompt,
+		Contexts:        payload.Contexts,
+		MaxOutputTokens: h.cfg.MaxOutputTokens,
+		ProviderBaseURL: h.cfg.ProviderBaseURL,
+	})
+	if err != nil {
+		if isTimeout(err) {
+			writeError(w, http.StatusGatewayTimeout, "provider_timeout", "LLM provider timed out.")
+			return
+		}
+		writeError(w, http.StatusBadGateway, "provider_error", "LLM provider request failed.")
+		return
+	}
+	if int64(len(resp.Text)) > h.cfg.MaxResponseBytes {
+		writeError(w, http.StatusBadGateway, "provider_error", "LLM provider request failed.")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, chatResponse{
+		Status:    "ok",
+		RequestID: h.requestID(),
+		Model:     safeModel(resp.Model, h.cfg.Model),
+		Text:      resp.Text,
+	})
+}
+
+func (h *Handler) requireAuthenticated(w http.ResponseWriter, r *http.Request) bool {
+	_, ok := h.userID(w, r)
+	return ok
+}
+
+func (h *Handler) userID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	userID, ok := r.Context().Value(UserIDContextKey).(int64)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication is required.")
+		return 0, false
+	}
+	return userID, true
+}
+
+func (h *Handler) unavailableReason() string {
+	if strings.TrimSpace(h.cfg.ProviderBaseURL) == "" ||
+		strings.TrimSpace(h.cfg.Model) == "" ||
+		strings.TrimSpace(h.cfg.APIKey) == "" {
+		return "not_configured"
+	}
+	if err := validateProviderURL(h.cfg.ProviderBaseURL); err != nil {
+		return "invalid_provider_url"
+	}
+	return ""
+}
+
+func (h *Handler) decodePayload(w http.ResponseWriter, r *http.Request) (chatPayload, bool) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, h.cfg.MaxBodyBytes+1))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid LLM request body.")
+		return chatPayload{}, false
+	}
+	if int64(len(body)) > h.cfg.MaxBodyBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "too_large", "LLM request is too large.")
+		return chatPayload{}, false
+	}
+	var payload chatPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid LLM request body.")
+		return chatPayload{}, false
+	}
+	return payload, true
+}
+
+func (h *Handler) validatePayload(w http.ResponseWriter, payload chatPayload) bool {
+	if !validAction(payload.Action) || strings.TrimSpace(payload.Prompt) == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid LLM request.")
+		return false
+	}
+	if len([]rune(payload.Prompt)) > h.cfg.MaxPromptChars {
+		writeError(w, http.StatusRequestEntityTooLarge, "too_large", "LLM request is too large.")
+		return false
+	}
+	if len(payload.Contexts) > h.cfg.MaxContextBlocks {
+		writeError(w, http.StatusRequestEntityTooLarge, "too_large", "LLM request is too large.")
+		return false
+	}
+	var totalContextBytes int64
+	for _, ctx := range payload.Contexts {
+		if ctx.Source != "selected-chat" && ctx.Source != "current-file" {
+			writeError(w, http.StatusBadRequest, "bad_request", "Invalid LLM context.")
+			return false
+		}
+		totalContextBytes += int64(len(ctx.Text))
+		if totalContextBytes > h.cfg.MaxContextBytes {
+			writeError(w, http.StatusRequestEntityTooLarge, "too_large", "LLM request is too large.")
+			return false
+		}
+	}
+	return true
+}
+
+func validAction(action string) bool {
+	switch action {
+	case "summarize", "rewrite", "draft", "ask":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Handler) trustedOrigin(r *http.Request) bool {
+	appOrigin := originOf(h.cfg.AppURL)
+	if appOrigin == "" {
+		return false
+	}
+	if origin := originOf(r.Header.Get("Origin")); origin != "" {
+		return origin == appOrigin
+	}
+	if referer := originOf(r.Header.Get("Referer")); referer != "" {
+		return referer == appOrigin
+	}
+	return false
+}
+
+func originOf(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return strings.ToLower(u.Scheme + "://" + u.Host)
+}
+
+func (h *Handler) providerClient() (Provider, error) {
+	if h.provider != nil {
+		return h.provider, nil
+	}
+	return NewOpenAIClient(h.cfg)
+}
+
+func safeModel(providerModel, configuredModel string) string {
+	if providerModel != "" {
+		return providerModel
+	}
+	return configuredModel
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, errorResponse{
+		Status:  "error",
+		Code:    code,
+		Message: message,
+	})
+}
+
+func newRequestID() string {
+	return fmt.Sprintf("llm-%d-%08x", time.Now().UnixNano(), rand.Uint32())
+}
+
+type captureResponseWriter struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func (w *captureResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *captureResponseWriter) WriteHeader(status int) {
+	if w.status == 0 {
+		w.status = status
+	}
+}
+
+func (w *captureResponseWriter) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.body.Write(data)
+}
+
+func AuthErrorJSON(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture := &captureResponseWriter{header: make(http.Header)}
+		next.ServeHTTP(capture, r)
+		status := capture.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		if status == http.StatusUnauthorized {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication is required.")
+			return
+		}
+		if status == http.StatusTooManyRequests {
+			writeError(w, http.StatusTooManyRequests, "rate_limited", "Request limit reached.")
+			return
+		}
+		for k, values := range capture.header {
+			for _, value := range values {
+				w.Header().Add(k, value)
+			}
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(capture.body.Bytes())
+	})
+}
+
+type windowCounter struct {
+	start time.Time
+	count int
+}
+
+type dailyCounter struct {
+	day   string
+	count int
+}
+
+type limits struct {
+	mu      sync.Mutex
+	userMin map[int64]windowCounter
+	ipMin   map[string]windowCounter
+	daily   map[int64]dailyCounter
+	active  map[int64]int
+}
+
+func newLimits() *limits {
+	return &limits{
+		userMin: make(map[int64]windowCounter),
+		ipMin:   make(map[string]windowCounter),
+		daily:   make(map[int64]dailyCounter),
+		active:  make(map[int64]int),
+	}
+}
+
+func (l *limits) reserve(userID int64, ip string, now time.Time, cfg Config) (func(), bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if cfg.UserConcurrency > 0 && l.active[userID] >= cfg.UserConcurrency {
+		return nil, false
+	}
+	if !allowMinute(l.userMin, userID, now, cfg.UserRequestsPerMinute) {
+		return nil, false
+	}
+	if !allowMinute(l.ipMin, ip, now, cfg.IPRequestsPerMinute) {
+		return nil, false
+	}
+	day := now.Format("2006-01-02")
+	daily := l.daily[userID]
+	if daily.day != day {
+		daily = dailyCounter{day: day}
+	}
+	if cfg.UserDailyQuota > 0 && daily.count >= cfg.UserDailyQuota {
+		return nil, false
+	}
+
+	incrementMinute(l.userMin, userID, now)
+	incrementMinute(l.ipMin, ip, now)
+	daily.count++
+	l.daily[userID] = daily
+	l.active[userID]++
+
+	return func() {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		if l.active[userID] > 0 {
+			l.active[userID]--
+		}
+	}, true
+}
+
+func allowMinute[K comparable](counters map[K]windowCounter, key K, now time.Time, limit int) bool {
+	if limit <= 0 {
+		return true
+	}
+	counter := counters[key]
+	if counter.start.IsZero() || now.Sub(counter.start) >= time.Minute {
+		return true
+	}
+	return counter.count < limit
+}
+
+func incrementMinute[K comparable](counters map[K]windowCounter, key K, now time.Time) {
+	counter := counters[key]
+	if counter.start.IsZero() || now.Sub(counter.start) >= time.Minute {
+		counter = windowCounter{start: now}
+	}
+	counter.count++
+	counters[key] = counter
+}
+
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	if r.RemoteAddr == "" {
+		return "unknown"
+	}
+	return r.RemoteAddr
+}
+
+func isTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrProviderTimeout) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/server/llm/handler_test.go
+++ b/server/llm/handler_test.go
@@ -1,0 +1,402 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusUnavailableIsSanitizedAndDoesNotContactProvider(t *testing.T) {
+	provider := &fakeProvider{}
+	handler := NewHandler(DefaultConfig(), WithProvider(provider))
+
+	req := authenticatedRequest(http.MethodPost, "/llmStatus", `{}`)
+	w := httptest.NewRecorder()
+	handler.Status(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 0, provider.calls())
+	require.NotContains(t, w.Body.String(), "sk-test")
+	require.NotContains(t, w.Body.String(), "llm.example.test")
+
+	var resp statusResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "ok", resp.Status)
+	require.False(t, resp.Available)
+	require.Equal(t, "not_configured", resp.Reason)
+}
+
+func TestChatValidatesPayloadOriginAndSizeBeforeProviderCall(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		origin     string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "invalid action",
+			body:       `{"action":"translate","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`,
+			origin:     "https://app.example.test",
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "bad_request",
+		},
+		{
+			name:       "missing origin",
+			body:       `{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`,
+			wantStatus: http.StatusForbidden,
+			wantCode:   "forbidden",
+		},
+		{
+			name:       "foreign origin",
+			body:       `{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`,
+			origin:     "https://evil.example.test",
+			wantStatus: http.StatusForbidden,
+			wantCode:   "forbidden",
+		},
+		{
+			name:       "oversized context",
+			body:       `{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"abcdef"}]}`,
+			origin:     "https://app.example.test",
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantCode:   "too_large",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &fakeProvider{}
+			cfg := testConfig()
+			cfg.MaxContextBytes = 5
+			handler := NewHandler(cfg, WithProvider(provider))
+
+			req := authenticatedRequest(http.MethodPost, "/llmChat", tt.body)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			w := httptest.NewRecorder()
+			handler.Chat(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			require.Equal(t, 0, provider.calls())
+			assertErrorCode(t, w.Body.Bytes(), tt.wantCode)
+		})
+	}
+}
+
+func TestChatRejectsRateQuotaAndConcurrencyBeforeProviderCall(t *testing.T) {
+	t.Run("rate limit", func(t *testing.T) {
+		provider := &fakeProvider{response: ChatResponse{Model: "test-model", Text: "ok"}}
+		cfg := testConfig()
+		cfg.UserRequestsPerMinute = 1
+		handler := NewHandler(cfg, WithProvider(provider), WithRequestID(func() string { return "req-rate" }))
+
+		first := authenticatedLLMChat(`{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`)
+		firstW := httptest.NewRecorder()
+		handler.Chat(firstW, first)
+		require.Equal(t, http.StatusOK, firstW.Code)
+
+		second := authenticatedLLMChat(`{"action":"ask","prompt":"again","contexts":[{"source":"selected-chat","text":"hello"}]}`)
+		secondW := httptest.NewRecorder()
+		handler.Chat(secondW, second)
+		require.Equal(t, http.StatusTooManyRequests, secondW.Code)
+		require.Equal(t, 1, provider.calls())
+		assertErrorCode(t, secondW.Body.Bytes(), "rate_limited")
+	})
+
+	t.Run("daily quota", func(t *testing.T) {
+		provider := &fakeProvider{response: ChatResponse{Model: "test-model", Text: "ok"}}
+		cfg := testConfig()
+		cfg.UserDailyQuota = 1
+		handler := NewHandler(cfg, WithProvider(provider), WithRequestID(func() string { return "req-quota" }))
+
+		firstW := httptest.NewRecorder()
+		handler.Chat(firstW, authenticatedLLMChat(`{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`))
+		require.Equal(t, http.StatusOK, firstW.Code)
+
+		secondW := httptest.NewRecorder()
+		handler.Chat(secondW, authenticatedLLMChat(`{"action":"ask","prompt":"again","contexts":[{"source":"selected-chat","text":"hello"}]}`))
+		require.Equal(t, http.StatusTooManyRequests, secondW.Code)
+		require.Equal(t, 1, provider.calls())
+		assertErrorCode(t, secondW.Body.Bytes(), "rate_limited")
+	})
+
+	t.Run("ip rate limit", func(t *testing.T) {
+		provider := &fakeProvider{response: ChatResponse{Model: "test-model", Text: "ok"}}
+		cfg := testConfig()
+		cfg.IPRequestsPerMinute = 1
+		handler := NewHandler(cfg, WithProvider(provider), WithRequestID(func() string { return "req-ip-rate" }))
+
+		firstW := httptest.NewRecorder()
+		handler.Chat(firstW, authenticatedLLMChat(`{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`))
+		require.Equal(t, http.StatusOK, firstW.Code)
+
+		secondW := httptest.NewRecorder()
+		handler.Chat(secondW, authenticatedLLMChat(`{"action":"ask","prompt":"again","contexts":[{"source":"selected-chat","text":"hello"}]}`))
+		require.Equal(t, http.StatusTooManyRequests, secondW.Code)
+		require.Equal(t, 1, provider.calls())
+		assertErrorCode(t, secondW.Body.Bytes(), "rate_limited")
+	})
+
+	t.Run("concurrency", func(t *testing.T) {
+		started := make(chan struct{})
+		release := make(chan struct{})
+		provider := &fakeProvider{fn: func(ctx context.Context, req ChatRequest) (ChatResponse, error) {
+			close(started)
+			<-release
+			return ChatResponse{Model: "test-model", Text: "ok"}, nil
+		}}
+		cfg := testConfig()
+		cfg.UserConcurrency = 1
+		handler := NewHandler(cfg, WithProvider(provider))
+
+		firstW := httptest.NewRecorder()
+		done := make(chan struct{})
+		go func() {
+			handler.Chat(firstW, authenticatedLLMChat(`{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`))
+			close(done)
+		}()
+		<-started
+
+		secondW := httptest.NewRecorder()
+		handler.Chat(secondW, authenticatedLLMChat(`{"action":"ask","prompt":"again","contexts":[{"source":"selected-chat","text":"hello"}]}`))
+		require.Equal(t, http.StatusTooManyRequests, secondW.Code)
+		assertErrorCode(t, secondW.Body.Bytes(), "rate_limited")
+
+		close(release)
+		<-done
+		require.Equal(t, http.StatusOK, firstW.Code)
+		require.Equal(t, 1, provider.calls())
+	})
+}
+
+func TestChatMapsProviderSuccessAndSanitizesProviderErrors(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var got ChatRequest
+		provider := &fakeProvider{fn: func(ctx context.Context, req ChatRequest) (ChatResponse, error) {
+			got = req
+			return ChatResponse{Model: "provider-model", Text: "draft text"}, nil
+		}}
+		handler := NewHandler(testConfig(), WithProvider(provider), WithRequestID(func() string { return "req-123" }))
+
+		w := httptest.NewRecorder()
+		handler.Chat(w, authenticatedLLMChat(`{"action":"summarize","prompt":"Summarize","contexts":[{"source":"selected-chat","label":"Selected","text":"hello"}],"providerBaseURL":"https://evil.example.test/v1"}`))
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "summarize", got.Action)
+		require.Equal(t, "Summarize", got.Prompt)
+		require.Equal(t, 1, len(got.Contexts))
+		require.Equal(t, 1024, got.MaxOutputTokens)
+		require.NotEqual(t, "https://evil.example.test/v1", got.ProviderBaseURL)
+
+		var resp chatResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Equal(t, "ok", resp.Status)
+		require.Equal(t, "req-123", resp.RequestID)
+		require.Equal(t, "provider-model", resp.Model)
+		require.Equal(t, "draft text", resp.Text)
+	})
+
+	t.Run("provider error is safe", func(t *testing.T) {
+		provider := &fakeProvider{err: errors.New("raw provider body with sk-test and prompt text")}
+		handler := NewHandler(testConfig(), WithProvider(provider))
+
+		w := httptest.NewRecorder()
+		handler.Chat(w, authenticatedLLMChat(`{"action":"ask","prompt":"secret prompt","contexts":[{"source":"selected-chat","text":"secret context"}]}`))
+
+		require.Equal(t, http.StatusBadGateway, w.Code)
+		body := w.Body.String()
+		require.NotContains(t, body, "sk-test")
+		require.NotContains(t, body, "secret prompt")
+		require.NotContains(t, body, "secret context")
+		require.NotContains(t, body, "raw provider body")
+		assertErrorCode(t, w.Body.Bytes(), "provider_error")
+	})
+}
+
+func TestChatMapsProviderTimeout(t *testing.T) {
+	provider := &fakeProvider{err: context.DeadlineExceeded}
+	cfg := testConfig()
+	cfg.Timeout = 10 * time.Millisecond
+	handler := NewHandler(cfg, WithProvider(provider))
+
+	w := httptest.NewRecorder()
+	handler.Chat(w, authenticatedLLMChat(`{"action":"ask","prompt":"hi","contexts":[{"source":"selected-chat","text":"hello"}]}`))
+
+	require.Equal(t, http.StatusGatewayTimeout, w.Code)
+	assertErrorCode(t, w.Body.Bytes(), "provider_timeout")
+}
+
+func TestAuthErrorJSONNormalizesMiddlewareFailures(t *testing.T) {
+	next := AuthErrorJSON(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+
+	w := httptest.NewRecorder()
+	next.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/llmChat", nil))
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	assertErrorCode(t, w.Body.Bytes(), "unauthorized")
+}
+
+func testConfig() Config {
+	cfg := DefaultConfig()
+	cfg.ProviderBaseURL = "https://llm.example.test/v1"
+	cfg.Model = "test-model"
+	cfg.APIKey = "sk-test"
+	cfg.AppURL = "https://app.example.test"
+	cfg.Timeout = time.Second
+	return cfg
+}
+
+func authenticatedLLMChat(body string) *http.Request {
+	req := authenticatedRequest(http.MethodPost, "/llmChat", body)
+	req.Header.Set("Origin", "https://app.example.test")
+	return req
+}
+
+func authenticatedRequest(method, target, body string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req.WithContext(context.WithValue(req.Context(), UserIDContextKey, int64(42)))
+}
+
+func assertErrorCode(t *testing.T, body []byte, want string) {
+	t.Helper()
+
+	var resp errorResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	require.Equal(t, "error", resp.Status)
+	require.Equal(t, want, resp.Code)
+	require.NotEmpty(t, resp.Message)
+}
+
+type fakeProvider struct {
+	mu       sync.Mutex
+	count    int
+	response ChatResponse
+	err      error
+	fn       func(context.Context, ChatRequest) (ChatResponse, error)
+}
+
+func (f *fakeProvider) Chat(ctx context.Context, req ChatRequest) (ChatResponse, error) {
+	f.mu.Lock()
+	f.count++
+	f.mu.Unlock()
+
+	if f.fn != nil {
+		return f.fn(ctx, req)
+	}
+	return f.response, f.err
+}
+
+func (f *fakeProvider) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.count
+}
+
+func decodeProviderRequest(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+
+	var payload map[string]any
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+	return payload
+}
+
+func TestOpenAIClientUsesConfiguredURLAndTokenCaps(t *testing.T) {
+	var got map[string]any
+	var gotAuth string
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		got = decodeProviderRequest(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"model":"returned-model","choices":[{"message":{"content":"provider draft"}}]}`))
+	}))
+	defer provider.Close()
+
+	cfg := testConfig()
+	cfg.ProviderBaseURL = provider.URL + "/v1"
+	cfg.MaxOutputTokens = 17
+	client, err := NewOpenAIClient(cfg)
+	require.NoError(t, err)
+
+	resp, err := client.Chat(context.Background(), ChatRequest{
+		Action:          "ask",
+		Prompt:          "answer this",
+		Contexts:        []ContextBlock{{Source: "selected-chat", Label: "Selected", Text: "hello"}},
+		MaxOutputTokens: 17,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "returned-model", resp.Model)
+	require.Equal(t, "provider draft", resp.Text)
+	require.Equal(t, "Bearer sk-test", gotAuth)
+	require.Equal(t, "test-model", got["model"])
+	require.Equal(t, float64(17), got["max_tokens"])
+	require.Equal(t, false, got["stream"])
+	require.NotContains(t, string(mustJSON(t, got)), "providerBaseURL")
+}
+
+func TestOpenAIClientRejectsUnsafeURLsAndSanitizesProviderFailures(t *testing.T) {
+	for _, rawURL := range []string{
+		"http://example.com/v1",
+		"ftp://localhost/v1",
+		"https://",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.ProviderBaseURL = rawURL
+			_, err := NewOpenAIClient(cfg)
+			require.Error(t, err)
+		})
+	}
+
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "secret raw body sk-test", http.StatusInternalServerError)
+	}))
+	defer provider.Close()
+
+	cfg := testConfig()
+	cfg.ProviderBaseURL = provider.URL + "/v1"
+	client, err := NewOpenAIClient(cfg)
+	require.NoError(t, err)
+
+	_, err = client.Chat(context.Background(), ChatRequest{Action: "ask", Prompt: "secret", MaxOutputTokens: 17})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "secret")
+	require.NotContains(t, err.Error(), "sk-test")
+}
+
+func TestOpenAIClientEnforcesResponseSizeCap(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("x"), 16))
+	}))
+	defer provider.Close()
+
+	cfg := testConfig()
+	cfg.ProviderBaseURL = provider.URL + "/v1"
+	cfg.MaxResponseBytes = 8
+	client, err := NewOpenAIClient(cfg)
+	require.NoError(t, err)
+
+	_, err = client.Chat(context.Background(), ChatRequest{Action: "ask", Prompt: "hi", MaxOutputTokens: 17})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "response_too_large")
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return data
+}

--- a/server/llm/openai.go
+++ b/server/llm/openai.go
@@ -1,0 +1,197 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var ErrProviderTimeout = errors.New("provider_timeout")
+
+type OpenAIClient struct {
+	cfg      Config
+	endpoint string
+	client   *http.Client
+}
+
+func NewOpenAIClient(cfg Config) (*OpenAIClient, error) {
+	cfg = cfg.withDefaults()
+	if err := validateProviderURL(cfg.ProviderBaseURL); err != nil {
+		return nil, err
+	}
+	endpoint, err := chatCompletionsEndpoint(cfg.ProviderBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OpenAIClient{
+		cfg:      cfg,
+		endpoint: endpoint,
+		client: &http.Client{
+			Timeout: cfg.Timeout,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}, nil
+}
+
+func (c *OpenAIClient) Chat(ctx context.Context, req ChatRequest) (ChatResponse, error) {
+	body, err := json.Marshal(openAIRequest{
+		Model:     c.cfg.Model,
+		Messages:  providerMessages(req),
+		MaxTokens: req.MaxOutputTokens,
+		Stream:    false,
+	})
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("provider_request_encode")
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("provider_request_build")
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		if isTimeout(err) {
+			return ChatResponse{}, ErrProviderTimeout
+		}
+		return ChatResponse{}, fmt.Errorf("provider_request_failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ChatResponse{}, fmt.Errorf("provider_status_%d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, c.cfg.MaxResponseBytes+1))
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("provider_response_read")
+	}
+	if int64(len(data)) > c.cfg.MaxResponseBytes {
+		return ChatResponse{}, fmt.Errorf("response_too_large")
+	}
+
+	var decoded openAIResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return ChatResponse{}, fmt.Errorf("provider_response_decode")
+	}
+	if len(decoded.Choices) == 0 || decoded.Choices[0].Message.Content == "" {
+		return ChatResponse{}, fmt.Errorf("provider_response_empty")
+	}
+
+	return ChatResponse{
+		Model: decoded.Model,
+		Text:  decoded.Choices[0].Message.Content,
+	}, nil
+}
+
+type openAIRequest struct {
+	Model     string          `json:"model"`
+	Messages  []openAIMessage `json:"messages"`
+	MaxTokens int             `json:"max_tokens"`
+	Stream    bool            `json:"stream"`
+}
+
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIResponse struct {
+	Model   string `json:"model"`
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+func providerMessages(req ChatRequest) []openAIMessage {
+	var b strings.Builder
+	b.WriteString("Action: ")
+	b.WriteString(req.Action)
+	b.WriteString("\n\nPrompt:\n")
+	b.WriteString(req.Prompt)
+	for i, ctx := range req.Contexts {
+		b.WriteString("\n\nContext ")
+		b.WriteString(fmt.Sprintf("%d", i+1))
+		b.WriteString(" (source: ")
+		b.WriteString(ctx.Source)
+		if ctx.Label != "" {
+			b.WriteString(", label: ")
+			b.WriteString(ctx.Label)
+		}
+		if ctx.Path != "" {
+			b.WriteString(", path: ")
+			b.WriteString(ctx.Path)
+		}
+		b.WriteString("):\n")
+		b.WriteString(ctx.Text)
+	}
+
+	return []openAIMessage{
+		{
+			Role:    "system",
+			Content: "You are an assistant inside Files.md. Return concise draft Markdown only. Do not mutate files.",
+		},
+		{
+			Role:    "user",
+			Content: b.String(),
+		},
+	}
+}
+
+func validateProviderURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid_provider_url")
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLocalOrPrivateHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("invalid_provider_url")
+	default:
+		return fmt.Errorf("invalid_provider_url")
+	}
+}
+
+func chatCompletionsEndpoint(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid_provider_url")
+	}
+	path := strings.TrimRight(u.Path, "/")
+	if !strings.HasSuffix(path, "/chat/completions") {
+		path += "/chat/completions"
+	}
+	u.Path = path
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+func isLocalOrPrivateHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}

--- a/server/sync/llm_routes_test.go
+++ b/server/sync/llm_routes_test.go
@@ -1,0 +1,76 @@
+package sync
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zakirullin/files.md/server/config"
+)
+
+func TestLLMRoutesAreAuthenticatedAndReturnNormalizedAuthErrors(t *testing.T) {
+	origCfg := config.ServerCfg
+	defer func() { config.ServerCfg = origCfg }()
+	resetAuthState(t)
+
+	config.ServerCfg = config.Config{
+		APIURL:    "https://api.example.test",
+		AppURL:    "https://app.example.test",
+		TokensDir: t.TempDir(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/llmStatus", nil)
+	w := httptest.NewRecorder()
+	router(log.New(io.Discard, "", 0)).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.JSONEq(t, `{"status":"error","code":"unauthorized","message":"Authentication is required."}`, w.Body.String())
+}
+
+func TestLLMRoutesUseExistingTokenMiddlewareAndDoNotExposeConfig(t *testing.T) {
+	origCfg := config.ServerCfg
+	defer func() { config.ServerCfg = origCfg }()
+	resetAuthState(t)
+
+	token := "valid-token"
+	tokensDir := t.TempDir()
+	config.ServerCfg = config.Config{
+		APIURL:             "https://api.example.test",
+		AppURL:             "https://app.example.test",
+		TokensDir:          tokensDir,
+		LLMProviderBaseURL: "https://llm.example.test/v1",
+		LLMModel:           "test-model",
+		LLMAPIKey:          "sk-test",
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(tokensDir, hashToken(token)), []byte("42"), 0o600))
+
+	req := httptest.NewRequest(http.MethodPost, "/llmStatus", nil)
+	req.Header.Set("Authorization", token)
+	w := httptest.NewRecorder()
+	router(log.New(io.Discard, "", 0)).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"available":true`)
+	require.Contains(t, w.Body.String(), `"model":"test-model"`)
+	require.NotContains(t, w.Body.String(), "sk-test")
+	require.NotContains(t, w.Body.String(), "llm.example.test")
+}
+
+func resetAuthState(t *testing.T) {
+	t.Helper()
+
+	mu.Lock()
+	oneTimeTokens = make(map[string]oneTimeToken)
+	mu.Unlock()
+
+	blockedIPsMutex.Lock()
+	blockedIPs = make(map[string]time.Time)
+	blockedIPsMutex.Unlock()
+}

--- a/server/sync/webserver.go
+++ b/server/sync/webserver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zakirullin/files.md/server/fs"
 	"github.com/zakirullin/files.md/server/habits"
 	"github.com/zakirullin/files.md/server/journal"
+	"github.com/zakirullin/files.md/server/llm"
 	"github.com/zakirullin/files.md/server/userconfig"
 )
 
@@ -124,6 +125,9 @@ func router(serverLogger *log.Logger) *http.ServeMux {
 		r.HandleFunc("/syncMediaFilenames", corsMiddleware(panicMiddleware(tokenMiddleware(gzipMiddleware(SyncMediaFilenames)))))
 		r.HandleFunc("/syncMediaFile", corsMiddleware(panicMiddleware(tokenMiddleware(gzipMiddleware(SyncMediaFile)))))
 		r.HandleFunc("/issuePermanentToken", corsMiddleware(panicMiddleware(IssueToken)))
+		llmHandler := llm.NewHandler(llm.FromServerConfig(config.ServerCfg))
+		r.HandleFunc("/llmStatus", corsMiddleware(panicMiddleware(llm.AuthErrorJSON(http.HandlerFunc(tokenMiddleware(llmHandler.Status))).ServeHTTP)))
+		r.HandleFunc("/llmChat", corsMiddleware(panicMiddleware(llm.AuthErrorJSON(http.HandlerFunc(tokenMiddleware(llmHandler.Chat))).ServeHTTP)))
 
 		// Deprecated due to cryptic names :) Will be removed soon.
 		r.HandleFunc("/syncTexts", corsMiddleware(panicMiddleware(tokenMiddleware(gzipMiddleware(SyncFilenames)))))

--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -1,10 +1,77 @@
 const {test, expect} = require('@playwright/test');
 
 test.beforeEach(async ({page}) => {
+    test.setTimeout(15000);
     await page.goto('/index.html');
 
     await page.waitForSelector('#tree', {timeout: 5000});
 });
+
+async function writeRootFile(page, path, content) {
+    await page.evaluate(async ({path, content}) => {
+        const root = await navigator.storage.getDirectory();
+        const parts = path.replace(/^\/+/, '').split('/');
+        const filename = parts.pop();
+        let dir = root;
+        for (const part of parts) {
+            dir = await dir.getDirectoryHandle(part, {create: true});
+        }
+        const fh = await dir.getFileHandle(filename, {create: true});
+        const w = await fh.createWritable();
+        await w.write(content);
+        await w.close();
+    }, {path, content});
+}
+
+async function useExplicitTestApi(page) {
+    await page.evaluate(() => {
+        localStorage.setItem('apiUrl', window.location.origin);
+        localStorage.removeItem('lastServerOk');
+    });
+}
+
+async function reloadApp(page) {
+    await page.reload();
+    await page.waitForSelector('#tree', {timeout: 5000});
+}
+
+async function waitForAssistantAvailable(page) {
+    await expect(page.locator('[data-testid="assistant-panel"]')).toHaveAttribute('data-available', 'true');
+}
+
+async function routeAssistantStatus(page, response) {
+    const requests = [];
+    await page.route('**/llmStatus', async route => {
+        requests.push(route.request());
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(response),
+        });
+    });
+    return requests;
+}
+
+async function routeAssistantChat(page, handler) {
+    const requests = [];
+    await page.route('**/llmChat', async route => {
+        const request = route.request();
+        requests.push(request);
+        const payload = request.postDataJSON();
+        const response = await handler(payload, request);
+        await route.fulfill({
+            status: response.status || 200,
+            contentType: 'application/json',
+            body: JSON.stringify(response.body || {
+                status: 'ok',
+                requestId: 'test-request',
+                model: 'test-model',
+                text: 'Draft from test assistant',
+            }),
+        });
+    });
+    return requests;
+}
 
 test('send message to chat', async ({ page }) => {
     await page.click(`#tree .tree-item:has-text('chat')`);
@@ -19,6 +86,310 @@ test('send message to chat', async ({ page }) => {
     let content = await page.textContent('.message-content')
     expect(content).toBe('My message');
 
+});
+
+test('does not probe llm status on default hosted api without linked server evidence', async ({page}) => {
+    await page.evaluate(() => {
+        localStorage.removeItem('apiUrl');
+        localStorage.removeItem('lastServerOk');
+    });
+    const statusRequests = await routeAssistantStatus(page, {
+        status: 'ok',
+        available: true,
+        model: 'should-not-be-probed',
+    });
+
+    await reloadApp(page);
+
+    await expect(page.locator('[data-testid="assistant-panel"]')).toHaveAttribute('data-available', 'false');
+    await expect(page.locator('[data-testid="assistant-action-selected"]')).toBeDisabled();
+    await page.waitForTimeout(300);
+    expect(statusRequests).toHaveLength(0);
+});
+
+test('ordinary chat capture never calls llmChat', async ({page}) => {
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    const chatRequests = await routeAssistantChat(page, async () => ({
+        body: {status: 'ok', requestId: 'unexpected', text: 'Should not happen'},
+    }));
+    await reloadApp(page);
+    await waitForAssistantAvailable(page);
+
+    await page.waitForSelector('#chat');
+    await page.locator('#chat-input').click();
+    await page.keyboard.type('Capture only');
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('.message-content').last()).toHaveText('Capture only');
+    expect(chatRequests).toHaveLength(0);
+});
+
+test('chat input switches between microphone and send controls', async ({page}) => {
+    await page.click(`#tree .tree-item:has-text('chat')`);
+    await page.waitForSelector('#chat');
+
+    await expect(page.locator('#mic-chat')).toBeVisible();
+    await expect(page.locator('#send-chat')).toBeHidden();
+
+    await page.locator('#chat-input').fill('Ready to send');
+    await expect(page.locator('#send-chat')).toBeVisible();
+    await expect(page.locator('#mic-chat')).toBeHidden();
+
+    await page.locator('#chat-input').fill('');
+    await expect(page.locator('#mic-chat')).toBeVisible();
+    await expect(page.locator('#send-chat')).toBeHidden();
+});
+
+test('journal suffix capture does not call llmChat', async ({page}) => {
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    const chatRequests = await routeAssistantChat(page, async () => ({
+        body: {status: 'ok', requestId: 'unexpected', text: 'Should not happen'},
+    }));
+    await reloadApp(page);
+
+    await page.click(`#tree .tree-item:has-text('chat')`);
+    await page.waitForSelector('#chat');
+    await page.locator('#chat-input').fill('Journal capture jj');
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('#tree')).toContainText('journal');
+    await expect(page.locator('#chat-input')).toHaveValue('');
+    const chatMessages = await page.locator('.message-content').allTextContents();
+    expect(chatMessages.join('\n')).not.toContain('Journal capture');
+    expect(chatRequests).toHaveLength(0);
+});
+
+test('pasted image capture inserts markdown and does not call llmChat', async ({page}) => {
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    const chatRequests = await routeAssistantChat(page, async () => ({
+        body: {status: 'ok', requestId: 'unexpected', text: 'Should not happen'},
+    }));
+    await reloadApp(page);
+
+    await page.click(`#tree .tree-item:has-text('chat')`);
+    await page.waitForSelector('#chat');
+    await page.locator('#chat-input').click();
+    await page.evaluate(() => {
+        const file = new File(['fake image'], 'clip.png', {type: 'image/png'});
+        const data = new DataTransfer();
+        data.items.add(file);
+        document.getElementById('chat-input').dispatchEvent(new ClipboardEvent('paste', {
+            clipboardData: data,
+            bubbles: true,
+            cancelable: true,
+        }));
+    });
+
+    await expect(page.locator('#chat-input')).toHaveValue(/!\[[^\]]+\.png\]\(media\/[^)]*\.png\)\n/);
+    expect(chatRequests).toHaveLength(0);
+});
+
+test('voice capture appends media markdown and does not call llmChat', async ({page}) => {
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    const chatRequests = await routeAssistantChat(page, async () => ({
+        body: {status: 'ok', requestId: 'unexpected', text: 'Should not happen'},
+    }));
+    await reloadApp(page);
+    await page.evaluate(() => {
+        Object.defineProperty(navigator, 'mediaDevices', {
+            configurable: true,
+            value: {
+                getUserMedia: async () => ({
+                    getTracks: () => [{stop() {}}],
+                }),
+            },
+        });
+        window.MediaRecorder = class FakeMediaRecorder {
+            static isTypeSupported() { return true; }
+            constructor() {
+                this.state = 'inactive';
+                this.mimeType = 'audio/webm';
+            }
+            start() {
+                this.state = 'recording';
+            }
+            stop() {
+                this.state = 'inactive';
+                this.ondataavailable?.({data: new Blob(['voice'], {type: 'audio/webm'})});
+                this.onstop?.();
+            }
+        };
+    });
+
+    await page.click(`#tree .tree-item:has-text('chat')`);
+    await page.waitForSelector('#chat');
+    await page.locator('#mic-chat').click();
+    await expect(page.locator('#mic-chat')).toHaveClass(/recording/);
+    await page.locator('#mic-chat').click();
+
+    await expect(page.locator('.message-content').last()).toHaveAttribute('data-text', /!\[\]\(media\/.*\.weba\)/);
+    expect(chatRequests).toHaveLength(0);
+});
+
+test('selected-chat assistant sends only selected texts and no unrelated app data', async ({page}) => {
+    await writeRootFile(page, '/Chat.md', [
+        '#### 4 June, Thursday',
+        '- [ ] `09:00` Selected item',
+        '- [ ] `09:01` Other item',
+        '',
+    ].join('\n'));
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    const payloads = [];
+    await routeAssistantChat(page, async payload => {
+        payloads.push(payload);
+        return {body: {status: 'ok', requestId: 'selected-1', model: 'test-model', text: 'Only first item'}};
+    });
+    await reloadApp(page);
+    await waitForAssistantAvailable(page);
+
+    await expect(page.locator('.message-content')).toHaveCount(2);
+
+    await page.locator('.message[data-text="Selected item"]').evaluate(el => {
+        document.querySelectorAll('.message.selected').forEach(message => message.classList.remove('selected'));
+        el.classList.add('selected');
+        updateAssistantPanel();
+    });
+    await expect(page.getByTestId('assistant-action-selected')).toBeEnabled();
+    await page.getByTestId('assistant-action-selected').click();
+    await page.getByTestId('assistant-send').click();
+
+    await expect(page.getByTestId('assistant-draft')).toContainText('Only first item');
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].action).toBe('summarize');
+    expect(payloads[0].contexts).toHaveLength(1);
+    expect(payloads[0].contexts[0]).toMatchObject({
+        source: 'selected-chat',
+        label: 'Selected chat entries',
+    });
+    expect(payloads[0].contexts[0].text).toContain('Selected item');
+    expect(payloads[0].contexts[0].text).not.toContain('Other item');
+    expect(JSON.stringify(payloads[0])).not.toContain('syncFilenames');
+    expect(JSON.stringify(payloads[0])).not.toContain('serverTime');
+    expect(JSON.stringify(payloads[0])).not.toContain('WELCOME_FILES');
+});
+
+test('current-file assistant requires confirmation and sends the labeled file only', async ({page}) => {
+    test.setTimeout(15000);
+    await writeRootFile(page, '/Notes.md', 'Important note body');
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    const payloads = [];
+    await routeAssistantChat(page, async payload => {
+        payloads.push(payload);
+        return {body: {status: 'ok', requestId: 'file-1', model: 'test-model', text: 'File draft'}};
+    });
+    await reloadApp(page);
+    await waitForAssistantAvailable(page);
+
+    await page.evaluate(() => openFile('/Notes.md'));
+    await page.evaluate(() => openChatModal());
+    await expect(page.getByTestId('assistant-action-current-file')).toBeEnabled();
+    await page.getByTestId('assistant-action-current-file').click({force: true});
+
+    await expect(page.getByTestId('assistant-context-label')).toContainText('/Notes.md');
+    await expect(page.getByTestId('assistant-send')).toBeDisabled();
+
+    await page.getByTestId('assistant-confirm-context').check();
+    await page.getByTestId('assistant-send').click();
+
+    await expect(page.getByTestId('assistant-draft')).toContainText('File draft');
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].contexts).toHaveLength(1);
+    expect(payloads[0].contexts[0]).toMatchObject({
+        source: 'current-file',
+        label: 'Current file: /Notes.md',
+        path: '/Notes.md',
+    });
+    expect(payloads[0].contexts[0].text).toContain('Important note body');
+    expect(JSON.stringify(payloads[0])).not.toContain('Selected item');
+    expect(JSON.stringify(payloads[0])).not.toContain('syncFilenames');
+});
+
+test('fullscreen Chat.md disables current-file assistant context', async ({page}) => {
+    test.setTimeout(15000);
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    await reloadApp(page);
+    await waitForAssistantAvailable(page);
+
+    await expect(page.getByTestId('assistant-action-current-file')).toBeDisabled();
+    await expect(page.getByTestId('assistant-context-label')).toContainText('Select chat entries or open a note');
+});
+
+test('current-file assistant context clears when switching to fullscreen Chat.md', async ({page}) => {
+    test.setTimeout(15000);
+    await writeRootFile(page, '/Notes.md', 'Important note body');
+    await writeRootFile(page, '/Chat.md', '#### 4 June, Thursday\n- [ ] `09:00` Selected item\n');
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    await reloadApp(page);
+    await waitForAssistantAvailable(page);
+
+    await page.click(`#tree .tree-item:has-text('Notes')`);
+    await page.evaluate(() => {
+        llmAssistantState.contexts = [{
+            source: 'current-file',
+            label: 'Current file: /Notes.md',
+            path: '/Notes.md',
+            text: 'Important note body',
+        }];
+        llmAssistantState.confirmed = true;
+        updateAssistantPanel();
+    });
+    await expect(page.getByTestId('assistant-context-label')).toContainText('/Notes.md');
+
+    await page.evaluate(async () => openChat());
+
+    await expect(page.getByTestId('assistant-action-current-file')).toBeDisabled();
+    await expect(page.getByTestId('assistant-context-label')).toContainText('Select chat entries or open a note');
+    await expect(page.getByTestId('assistant-confirm-context')).not.toBeVisible();
+});
+
+test('assistant draft can append to Chat.md and insert into the current file', async ({page}) => {
+    test.setTimeout(15000);
+    await writeRootFile(page, '/Notes.md', 'Original note');
+    await useExplicitTestApi(page);
+    await routeAssistantStatus(page, {status: 'ok', available: true, model: 'test-model'});
+    await routeAssistantChat(page, async () => ({
+        body: {
+            status: 'ok',
+            requestId: 'draft-1',
+            model: 'test-model',
+            text: 'Heading\n- [ ] checklist-looking\n> quote',
+        },
+    }));
+    await reloadApp(page);
+    await waitForAssistantAvailable(page);
+
+    await page.evaluate(() => openFile('/Notes.md'));
+    await page.evaluate(() => openChatModal());
+    await expect(page.getByTestId('assistant-action-current-file')).toBeEnabled();
+    await page.getByTestId('assistant-action-current-file').click({force: true});
+    await page.getByTestId('assistant-confirm-context').check();
+    await page.getByTestId('assistant-send').click();
+    await expect(page.getByTestId('assistant-draft')).toContainText('Heading');
+
+    await page.getByTestId('assistant-append-chat').click();
+    await page.click(`#tree .tree-item:has-text('chat')`);
+    await expect(page.locator('.message-content').last()).toContainText('AI: Heading');
+    await expect(page.locator('.message-content').last()).toContainText('- [ ] checklist-looking');
+
+    await page.evaluate(() => openFile('/Notes.md'));
+    await page.evaluate(() => openChatModal());
+    await expect(page.getByTestId('assistant-action-current-file')).toBeEnabled();
+    await page.getByTestId('assistant-action-current-file').click({force: true});
+    await page.getByTestId('assistant-confirm-context').check();
+    await page.getByTestId('assistant-send').click();
+    await page.getByTestId('assistant-insert-current').click();
+
+    const content = await page.evaluate(() => document.querySelector('.CodeMirror').CodeMirror.getValue());
+    expect(content).toContain('Original note');
+    expect(content).toContain('Heading');
 });
 
 test('select all in chat input selects input text, not bubbles', async ({page}) => {
@@ -62,7 +433,7 @@ test('move to dir creates a new file inside that dir', async ({page}) => {
     await page.locator('.to-file-btn').first().click({force: true});
     await page.waitForSelector('#search', {state: 'visible'});
 
-    await page.locator('#search-results li[data-dir="projects"]').click();
+    await page.locator('#search-results li[data-dir="projects"]').evaluate(el => el.click());
     await page.waitForSelector('.message', {state: 'detached'});
 
     const exists = await page.evaluate(async () => {
@@ -190,7 +561,7 @@ test('move to recent file does not prepend a timestamp', async ({page}) => {
     await page.waitForSelector('.message');
 
     await page.hover('.message');
-    await page.locator('.action-btn').filter({hasText: 'File'}).click({force: true});
+    await page.locator('.to-recent-btn[data-filename="File.md"]').click({force: true});
     await page.waitForSelector('.message', {state: 'detached'});
 
     await page.click(`#tree .tree-item:has-text('File')`);
@@ -253,7 +624,7 @@ test('send to chat and move to recent file', async ({ page }) => {
     expect(content).toBe('My message');
 
     await page.hover('.message');
-    await page.locator('.action-btn').filter({hasText: 'File'}).click({force: true});
+    await page.locator('.to-recent-btn[data-filename="File.md"]').click({force: true});
     await page.waitForSelector('.message', {state: 'detached'});
 
     await page.click(`#tree .tree-item:has-text('File')`);

--- a/tests/editor.spec.js
+++ b/tests/editor.spec.js
@@ -51,12 +51,14 @@ test('should load the Files.md editor', async ({page}) => {
 });
 
 test('should open markdown file via quick panel and see bold text formatting', async ({page}) => {
-    const isMac = process.platform === 'darwin';
-    const modifier = isMac ? 'Meta' : 'Control';
-    await page.keyboard.press(`${modifier}+k`);
+    // Use the cross-platform app shortcut instead of Meta+K; Chromium can
+    // leave Meta in a sticky focus state across serial tests on macOS hosts.
+    await page.keyboard.press('Control+k');
 
     await page.waitForSelector('#search', {timeout: 3000});
     await page.locator('#search-input').fill('Markdown');
+    await page.locator('#search-input').dispatchEvent('input');
+    await expect(page.locator('#search-results li')).not.toHaveCount(0);
     await page.keyboard.press('Enter');
 
     // Read the main editor's value directly. Two CodeMirror instances live
@@ -404,4 +406,3 @@ test('should handle partical text selection for word-wrap content', async ({page
         expect(selectionData.right).toBe(expectedSelections[i].right);
     }
 });
-

--- a/web/app.css
+++ b/web/app.css
@@ -14,6 +14,20 @@
     "Roboto Mono", "DejaVu Sans Mono", "Liberation Mono", Menlo, Monaco,
     "Consolas", "Source Code Pro", monospace;
     --normal-width: 800px;
+    --surface-canvas: linear-gradient(135deg, #e9f6f3 0%, #f7f5ec 44%, #fff1df 100%);
+    --surface-bg: color-mix(in srgb, var(--col-bg) 96%, #fff);
+    --surface-glass: rgba(255, 252, 240, 0.72);
+    --surface-glass-strong: rgba(255, 252, 240, 0.86);
+    --surface-border: rgba(95, 102, 94, 0.22);
+    --surface-highlight: rgba(255, 255, 255, 0.58);
+    --surface-shadow: 0 20px 58px rgba(42, 39, 31, 0.16);
+    --surface-shadow-soft: 0 10px 30px rgba(42, 39, 31, 0.1);
+    --radius-panel: 24px;
+    --radius-control: 12px;
+    --radius-pill: 999px;
+    --blur-panel: 22px;
+    --blur-control: 14px;
+    --transition-fast: 150ms ease;
     -webkit-font-smoothing: antialiased;
     color-scheme: light dark;
 }
@@ -21,6 +35,50 @@
 @media (prefers-color-scheme: light) {
     meta[name="theme-color"] {
         content: "#ff0000";
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --surface-canvas: linear-gradient(135deg, #142329 0%, #252421 52%, #30261d 100%);
+        --surface-bg: color-mix(in srgb, var(--col-bg) 96%, #000);
+        --surface-glass: rgba(31, 30, 29, 0.72);
+        --surface-glass-strong: rgba(38, 38, 36, 0.88);
+        --surface-border: rgba(232, 227, 216, 0.16);
+        --surface-highlight: rgba(255, 255, 255, 0.12);
+        --surface-shadow: 0 22px 64px rgba(0, 0, 0, 0.34);
+        --surface-shadow-soft: 0 12px 34px rgba(0, 0, 0, 0.24);
+    }
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+    :root {
+        --surface-glass: color-mix(in srgb, var(--col-bg-alt) 94%, var(--col-bg));
+        --surface-glass-strong: color-mix(in srgb, var(--col-bg-alt) 98%, var(--col-bg));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    :root {
+        --transition-fast: 0ms linear;
+    }
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        scroll-behavior: auto !important;
+        transition-duration: 0.001ms !important;
+    }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+    :root {
+        --surface-glass: var(--col-bg-alt);
+        --surface-glass-strong: var(--col-bg);
+        --blur-panel: 0px;
+        --blur-control: 0px;
     }
 }
 
@@ -33,7 +91,7 @@ html {
 
 body {
     overscroll-behavior: none;
-    background-color: var(--col-bg-alt);
+    background: var(--surface-canvas);
     color: var(--col-tx);
     font-size: 1.7rem;
     font-size: calc(1.5rem + 0.2vw);
@@ -41,6 +99,23 @@ body {
     text-rendering: optimizeLegibility;
     display: flex;
     height: 100vh;
+    overflow: hidden;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: rgba(20, 20, 18, 0.08);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--transition-fast);
+    z-index: 9990;
+}
+
+body:has(#search[style*="display: flex"])::before,
+body:has(#move[style*="display: flex"])::before {
+    opacity: 1;
 }
 
 /*Add border for PWA app only*/
@@ -68,19 +143,24 @@ body {
 
 #sidebar {
     flex-shrink: 0; /* Prevent flexbox from shrinking */
-    box-sizing: content-box !important;
+    box-sizing: border-box !important;
     display: block;
     width: 280px !important;
     /*min-width: 220px;*/
     /*max-width: 800px;*/
     position: relative;
     overflow: auto;
-    height: 100%;
-    background: var(--col-bg-alt);
+    height: calc(100vh - 24px);
+    margin: 12px;
+    background: var(--surface-glass);
     color: var(--col-tx-alt);
     font-size: calc(1.5rem);
-    padding-left: 5px;
-    border-right: 1px solid var(--col-border);
+    padding: 8px;
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-panel);
+    box-shadow: var(--surface-shadow);
+    backdrop-filter: blur(var(--blur-panel)) saturate(1.28);
+    -webkit-backdrop-filter: blur(var(--blur-panel)) saturate(1.28);
 }
 
 #sidebar > ul {
@@ -125,7 +205,8 @@ body {
     width: 100%;
     display: flex;
     flex-direction: column;
-    background: var(--col-bg);
+    background: var(--surface-bg);
+    min-width: 0;
 }
 #editor-container {
     flex: 1;
@@ -330,10 +411,13 @@ a:hover {
 #search, #move {
     position: fixed;
     width: 500px;
-    padding: 5px;
-    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.15);
-    border-radius: 8px;
-    background: var(--col-bg);
+    padding: 8px;
+    box-shadow: var(--surface-shadow);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-panel);
+    background: var(--surface-glass-strong);
+    backdrop-filter: blur(var(--blur-panel)) saturate(1.24);
+    -webkit-backdrop-filter: blur(var(--blur-panel)) saturate(1.24);
     display: flex;
     flex-direction: column;
     z-index: 10000;
@@ -341,17 +425,21 @@ a:hover {
 
 #search-input, #move-input {
     width: 100%;
-    padding: 8px;
+    padding: 10px 12px;
     font-size: 16px;
-    margin-bottom: 4px;
+    margin-bottom: 6px;
     box-sizing: border-box;
-    border: 2px solid var(--col-border);
-    border-radius: 4px;
-    background: var(--col-bg);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-control);
+    background: color-mix(in srgb, var(--col-bg) 84%, transparent);
+    color: var(--col-tx);
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
 }
 
 #search-input:focus, #move-input:focus {
     outline: none;
+    border-color: color-mix(in srgb, var(--color-neo-orange) 58%, var(--surface-border));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-neo-orange) 16%, transparent);
 }
 
 #search-results, #move-results {
@@ -369,11 +457,14 @@ a:hover {
     word-break: break-all; /* Break long paths anywhere */
     overflow: hidden;
     white-space: nowrap;
+    border-radius: var(--radius-control);
+    transition: background-color var(--transition-fast), color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 #search-results .focused, #move-results .focused {
-    background-color: var(--col-bg-active);
-    border-radius: 5px;
+    background: color-mix(in srgb, var(--color-neo-orange) 8%, var(--col-bg-active));
+    color: var(--col-tx);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-neo-orange) 22%, transparent);
 }
 
 .CodeMirror-scroll {
@@ -585,21 +676,36 @@ a:hover {
     color: transparent;
 }
 
- #toolbar {
-     z-index: 5;
-     position: fixed;
-     left: 240px;
-     top: 30px;
-     background: var(--col-bg-alt);
-     text-align: center;
- }
+#toolbar {
+    z-index: 10;
+    position: sticky;       /* stays at the top while scrolling */
+    top: 0;
+    left: auto;
+    width: max-content;
+    margin: 0 auto 8px;
+    padding: 6px;
+    background: var(--surface-glass-strong);
+    text-align: center;
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-pill);
+    box-shadow: var(--surface-shadow-soft);
+    backdrop-filter: blur(var(--blur-control)) saturate(1.22);
+    -webkit-backdrop-filter: blur(var(--blur-control)) saturate(1.22);
+}
 
 #toolbar button {
-    background: none;
+    background: transparent;
     border: none;
     cursor: pointer;
-    padding: 2px;
-    margin: 0 2px;
+    padding: 5px;
+    margin: 0 1px;
+    border-radius: var(--radius-pill);
+    transition: background-color var(--transition-fast), transform var(--transition-fast), color var(--transition-fast);
+}
+
+#toolbar button:hover {
+    background: color-mix(in srgb, var(--col-bg-active) 76%, transparent);
+    transform: translateY(-1px);
 }
 
 button svg {
@@ -702,14 +808,6 @@ button svg circle {
     opacity: 1;
     transition-delay: 0.25s;
 }
-
-#toolbar {
-    position: sticky;       /* stays at the top while scrolling */
-    top: 0;
-    padding-top: 8px;
-    z-index: 10;
-}
-
 
 body.dragging {
     user-select: none;
@@ -960,13 +1058,17 @@ pre.HyperMD-codeblock-end {
 }
 
 #nav-buttons {
-    background: var(--col-bg-alt);
-    border-radius: 10px;
+    background: var(--surface-glass-strong);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--radius-pill);
+    box-shadow: var(--surface-shadow-soft);
+    backdrop-filter: blur(var(--blur-control)) saturate(1.18);
+    -webkit-backdrop-filter: blur(var(--blur-control)) saturate(1.18);
     display: flex;
     position: absolute;
-    padding: 0 6px;
-    top: 2px;
-    right: 2px;
+    padding: 3px 7px;
+    top: 10px;
+    right: 10px;
 }
 
 .sidebar-blink {

--- a/web/app.js
+++ b/web/app.js
@@ -461,7 +461,7 @@ function doResize(e) {
     if (!isResizing) return;
 
     log(e);
-    const width = e.clientX;
+    const width = e.clientX - sidebar.getBoundingClientRect().left;
     const minWidth = 200;
     const maxWidth = 600;
 

--- a/web/chat.css
+++ b/web/chat.css
@@ -1,17 +1,58 @@
 #chat {
     flex: 1;
     overflow-y: auto;
-    padding: 24px;
+    padding: 24px clamp(16px, 4vw, 48px);
     display: flex;
     flex-direction: column;
     position: relative;
+    gap: 8px;
 }
 
 #chat-container {
     display: flex;
     flex-direction: column;
     height: 100%;
-    background: var(--col-bg);
+    background: var(--surface-canvas);
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+#chat-container::before,
+#chat-container::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+}
+
+#chat-container::before {
+    background:
+        linear-gradient(118deg, rgba(19, 183, 216, 0.22) 0%, rgba(19, 183, 216, 0.1) 22%, rgba(19, 183, 216, 0) 46%),
+        linear-gradient(24deg, rgba(232, 145, 45, 0.18) 0%, rgba(232, 145, 45, 0.08) 18%, rgba(232, 145, 45, 0) 40%),
+        repeating-linear-gradient(90deg, rgba(26, 26, 26, 0.032) 0 1px, transparent 1px 64px),
+        repeating-linear-gradient(0deg, rgba(26, 26, 26, 0.026) 0 1px, transparent 1px 64px);
+    mix-blend-mode: multiply;
+}
+
+#chat-container::after {
+    top: auto;
+    height: 42%;
+    background:
+        linear-gradient(180deg, color-mix(in srgb, var(--col-bg) 0%, transparent) 0%, color-mix(in srgb, var(--col-bg) 72%, transparent) 72%),
+        linear-gradient(135deg, rgba(19, 183, 216, 0.24), rgba(232, 145, 45, 0.18));
+    clip-path: polygon(0 54%, 11% 47%, 23% 61%, 37% 42%, 53% 63%, 68% 45%, 84% 58%, 100% 39%, 100% 100%, 0 100%);
+    opacity: 0.58;
+}
+
+#chat,
+.chat-assistant-panel,
+#chat-input-wrap,
+#close-chat,
+#fullscreen-chat {
+    position: relative;
+    z-index: 1;
 }
 
 #chat-container.modal {
@@ -22,10 +63,55 @@
     max-height: 500px !important;
     height: auto !important;
     min-height: 310px;
-    border: 1px solid var(--col-border);
+    border: 1px solid var(--surface-border);
     padding-top: 35px;
-    border-radius: 15px;
+    border-radius: var(--radius-panel);
     z-index: 10;
+    box-shadow: var(--surface-shadow);
+    backdrop-filter: blur(var(--blur-panel)) saturate(1.24);
+    -webkit-backdrop-filter: blur(var(--blur-panel)) saturate(1.24);
+}
+
+#chat-container.modal::before {
+    opacity: 0.82;
+}
+
+#chat-container.modal::after {
+    height: 48%;
+    opacity: 0.3;
+}
+
+@media (prefers-color-scheme: dark) {
+    #chat-container {
+        background: var(--surface-canvas);
+    }
+
+    #chat-container::before {
+        background:
+            linear-gradient(118deg, rgba(19, 183, 216, 0.22) 0%, rgba(19, 183, 216, 0.08) 24%, rgba(19, 183, 216, 0) 48%),
+            linear-gradient(24deg, rgba(232, 145, 45, 0.16) 0%, rgba(232, 145, 45, 0.06) 20%, rgba(232, 145, 45, 0) 44%),
+            repeating-linear-gradient(90deg, rgba(232, 227, 216, 0.035) 0 1px, transparent 1px 64px),
+            repeating-linear-gradient(0deg, rgba(232, 227, 216, 0.025) 0 1px, transparent 1px 64px);
+        mix-blend-mode: normal;
+    }
+
+    #chat-container::after {
+        background:
+            linear-gradient(180deg, rgba(38, 38, 36, 0) 0%, rgba(38, 38, 36, 0.8) 74%),
+            linear-gradient(135deg, rgba(19, 183, 216, 0.18), rgba(232, 145, 45, 0.13));
+        opacity: 0.44;
+    }
+}
+
+#chat-container.modal #chat {
+    padding: 14px;
+}
+
+#chat-container.modal .chat-assistant-panel,
+#chat-container.modal #chat-input-wrap {
+    width: calc(100% - 28px);
+    margin-left: 14px;
+    margin-right: 14px;
 }
 
 #chat::before {
@@ -34,12 +120,17 @@
 }
 
 .message {
-    background: var(--col-bg-alt);
-    padding: 4px 8px 4px 36px;
+    background: color-mix(in srgb, var(--col-bg-alt) 82%, transparent);
+    width: min(100%, 1120px);
+    align-self: center;
+    box-sizing: border-box;
+    padding: 10px 44px 10px 42px;
     position: relative;
-    animation: slideIn 0.3s ease-out;
+    animation: slideIn 0.24s ease-out both;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+    border: 1px solid transparent;
+    border-radius: 8px;
 }
 
 .complete-btn {
@@ -89,21 +180,10 @@
     stroke-width: 4;
 }
 
-.message:first-child {
-    border-radius: 6px 6px 0 0;
-}
-
-.message:last-child {
-    border-radius: 0 0 6px 6px;
-}
-
-.message:only-child {
-    border-radius: 6px;
-}
-
 .message:hover:not(:has(.complete-btn:hover)) {
     background: var(--col-bg-active);
     z-index: 1;
+    box-shadow: 0 8px 24px color-mix(in srgb, var(--col-tx) 10%, transparent);
 }
 
 
@@ -140,6 +220,7 @@
     transition: background 0.2s;
     font-size: 15px;
     color: var(--col-tx);
+    overflow-wrap: anywhere;
     /*margin-bottom: 4px;*/
     /*word-wrap: break-word;*/
 }
@@ -346,6 +427,7 @@
     align-items: center;
     justify-content: center;
     text-align: center;
+    padding: 24px;
 }
 
 .empty-icon {
@@ -366,14 +448,18 @@
 }
 
 #chat-input-wrap {
-    margin: 0 24px 24px 24px;
+    width: min(calc(100% - 48px), 1120px);
+    margin: 0 auto 24px;
+    flex-shrink: 0;
 }
 
 #chat-input {
-    background: var(--col-bg-alt);
-    border: 1px solid transparent;
-    border-radius: 25px !important;
-    padding: 14px 64px 14px 22px;
+    background: var(--surface-glass-strong);
+    backdrop-filter: blur(var(--blur-control)) saturate(1.2);
+    -webkit-backdrop-filter: blur(var(--blur-control)) saturate(1.2);
+    border: 1px solid var(--surface-border);
+    border-radius: 28px !important;
+    padding: 16px 64px 16px 24px;
     font-size: 16px;
     resize: none;
     min-height: 42px;
@@ -382,11 +468,14 @@
     box-sizing: border-box;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.4;
+    box-shadow: 0 14px 38px color-mix(in srgb, var(--col-tx) 9%, transparent);
+    transition: border-color 0.18s, box-shadow 0.18s, background-color 0.18s;
 }
 
 #chat-input:focus {
     outline: none;
-    border: 1px solid var(--col-border);
+    border-color: color-mix(in srgb, var(--color-neo-orange) 55%, var(--col-border));
+    box-shadow: 0 16px 42px color-mix(in srgb, var(--color-neo-orange) 14%, transparent);
 }
 
 #send-chat {
@@ -466,8 +555,277 @@
 }
 
 .message.selected {
-    background: var(--col-msg-sel);
-    border-color: var(--col-link);
+    background:
+        linear-gradient(90deg,
+            color-mix(in srgb, #13b7d8 16%, var(--col-bg-alt)),
+            color-mix(in srgb, var(--col-link) 12%, var(--col-bg-alt)));
+    border-color: color-mix(in srgb, #13b7d8 70%, var(--col-link));
+    box-shadow: inset 3px 0 0 #13b7d8;
+}
+
+.chat-assistant-panel {
+    --assistant-cyan: #13b7d8;
+    --assistant-ink-soft: color-mix(in srgb, var(--col-tx) 72%, var(--col-tx-alt));
+    --assistant-border: var(--surface-border);
+    --assistant-border-warm: var(--surface-border);
+    width: min(calc(100% - 48px), 1120px);
+    box-sizing: border-box;
+    margin: 12px auto 12px;
+    padding: 12px;
+    border: 1px solid var(--assistant-border);
+    border-radius: var(--radius-panel);
+    background:
+        linear-gradient(135deg,
+            color-mix(in srgb, var(--assistant-cyan) 8%, transparent),
+            transparent 32%),
+        var(--surface-glass);
+    display: grid;
+    gap: 8px;
+    flex-shrink: 0;
+    box-shadow: 0 18px 48px color-mix(in srgb, var(--col-tx) 10%, transparent);
+    backdrop-filter: blur(var(--blur-panel)) saturate(1.22);
+    -webkit-backdrop-filter: blur(var(--blur-panel)) saturate(1.22);
+}
+
+.assistant-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.assistant-identity {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.assistant-orb {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background:
+        radial-gradient(circle at 30% 30%, #ffffff 0 12%, transparent 13%),
+        linear-gradient(135deg, var(--assistant-cyan), var(--color-neo-orange));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--assistant-cyan) 12%, transparent);
+    flex: 0 0 auto;
+}
+
+.assistant-title {
+    color: var(--col-tx);
+    font-size: 13px;
+    font-weight: 650;
+    letter-spacing: 0;
+}
+
+.assistant-toolbar,
+.assistant-compose,
+.assistant-draft-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.assistant-toolbar {
+    flex-wrap: wrap;
+    padding: 3px;
+    border: 1px solid var(--assistant-border-warm);
+    border-radius: var(--radius-control);
+    background: color-mix(in srgb, var(--col-bg) 72%, transparent);
+    width: fit-content;
+    max-width: 100%;
+}
+
+.assistant-action,
+.assistant-send,
+.assistant-draft-actions button {
+    border: 1px solid var(--assistant-border-warm);
+    background: color-mix(in srgb, var(--col-bg) 88%, transparent);
+    color: var(--assistant-ink-soft);
+    border-radius: var(--radius-control);
+    min-height: 32px;
+    padding: 0 12px;
+    cursor: pointer;
+    font-size: 13px;
+    transition: background-color 0.16s, border-color 0.16s, color 0.16s, transform 0.16s, box-shadow 0.16s;
+}
+
+.assistant-action.active,
+.assistant-send:not(:disabled) {
+    border-color: color-mix(in srgb, var(--assistant-cyan) 52%, var(--color-neo-orange));
+    background: color-mix(in srgb, var(--assistant-cyan) 14%, var(--col-bg));
+    color: var(--col-tx);
+    box-shadow: 0 4px 14px color-mix(in srgb, var(--assistant-cyan) 14%, transparent);
+}
+
+.assistant-send:not(:disabled) {
+    background: var(--color-neo-orange);
+    border-color: var(--color-neo-orange);
+    color: var(--col-bg);
+    font-weight: 650;
+}
+
+.assistant-action:not(:disabled):hover,
+.assistant-send:not(:disabled):hover,
+.assistant-draft-actions button:not(:disabled):hover {
+    transform: translateY(-1px);
+    border-color: color-mix(in srgb, var(--assistant-cyan) 52%, var(--assistant-border-warm));
+}
+
+.assistant-action:focus-visible,
+.assistant-send:focus-visible,
+.assistant-draft-actions button:focus-visible,
+.assistant-prompt:focus-visible,
+#chat-input:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--assistant-cyan, #13b7d8) 60%, var(--color-neo-orange));
+    outline-offset: 2px;
+}
+
+.assistant-action:disabled,
+.assistant-send:disabled,
+.assistant-draft-actions button:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.assistant-status {
+    border: 1px solid var(--assistant-border-warm);
+    border-radius: var(--radius-pill);
+    padding: 4px 9px 4px 20px;
+    color: var(--col-tx-alt);
+    font-size: 12px;
+    position: relative;
+    max-width: 42%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    background: color-mix(in srgb, var(--col-bg) 72%, transparent);
+}
+
+.assistant-status::before {
+    content: '';
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    width: 6px;
+    height: 6px;
+    transform: translateY(-50%);
+    border-radius: 50%;
+    background: var(--assistant-cyan);
+}
+
+.chat-assistant-panel.is-unavailable .assistant-status::before {
+    background: var(--col-tx-alt);
+}
+
+.chat-assistant-panel.is-loading .assistant-status::before {
+    background: var(--color-neo-orange);
+    animation: assistant-pulse 1.1s ease-in-out infinite;
+}
+
+@keyframes assistant-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-neo-orange) 48%, transparent); }
+    50% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--color-neo-orange) 8%, transparent); }
+}
+
+.assistant-context {
+    min-height: 20px;
+    color: var(--assistant-ink-soft);
+    font-size: 13px;
+    overflow-wrap: anywhere;
+    padding: 2px 1px;
+}
+
+.assistant-confirm {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    color: var(--assistant-ink-soft);
+    font-size: 13px;
+}
+
+.assistant-confirm input {
+    accent-color: var(--color-neo-orange);
+}
+
+.assistant-compose {
+    align-items: stretch;
+    gap: 8px;
+}
+
+.assistant-prompt {
+    min-width: 0;
+    flex: 1;
+    border: 1px solid var(--assistant-border-warm);
+    background: color-mix(in srgb, var(--col-bg) 88%, transparent);
+    color: var(--col-tx);
+    border-radius: var(--radius-control);
+    padding: 8px 11px;
+    font-size: 14px;
+    min-height: 34px;
+    box-sizing: border-box;
+    transition: border-color 0.16s, box-shadow 0.16s, background-color 0.16s;
+}
+
+.assistant-prompt:focus {
+    outline: none;
+    border-color: color-mix(in srgb, var(--assistant-cyan) 70%, var(--col-link));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--assistant-cyan) 12%, transparent);
+}
+
+.assistant-error {
+    color: var(--color-neo-orange);
+    font-size: 13px;
+}
+
+.assistant-draft {
+    border: 1px solid var(--assistant-border-warm);
+    border-radius: var(--radius-control);
+    padding: 10px;
+    background: color-mix(in srgb, var(--col-bg) 80%, transparent);
+    display: grid;
+    gap: 8px;
+}
+
+.assistant-draft[hidden] {
+    display: none;
+}
+
+.assistant-draft-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    color: var(--col-tx);
+    font-size: 13px;
+    font-weight: 650;
+}
+
+.assistant-draft-model {
+    min-width: 0;
+    color: var(--col-tx-alt);
+    font-weight: 400;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.assistant-draft-text {
+    margin: 0;
+    max-height: 180px;
+    overflow: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    color: var(--col-tx);
+    font: inherit;
+    line-height: 1.5;
+    padding: 2px 0;
+}
+
+.chat-assistant-panel.is-unavailable .assistant-compose,
+.chat-assistant-panel.is-unavailable .assistant-confirm {
+    opacity: 0.65;
 }
 
 .message-content {
@@ -566,6 +924,49 @@
     justify-content: center;
     border-radius: 50%;
     transition: background-color 0.2s;
+}
+
+@media (max-width: 640px) {
+    #chat {
+        padding: 14px;
+    }
+
+    #chat-container.modal {
+        left: 10px;
+        right: 10px;
+        bottom: 10px;
+        width: auto !important;
+        max-height: calc(100vh - 20px) !important;
+    }
+
+    .chat-assistant-panel,
+    #chat-input-wrap {
+        width: calc(100% - 28px);
+        margin-left: 14px;
+        margin-right: 14px;
+    }
+
+    .assistant-head {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .assistant-compose {
+        flex-direction: column;
+    }
+
+    .assistant-status {
+        width: 100%;
+        max-width: 100%;
+        margin-left: 0;
+        box-sizing: border-box;
+    }
+
+    .message-actions {
+        max-width: calc(100vw - 48px);
+        overflow-x: auto;
+    }
 }
 
 .modal-reversed {

--- a/web/chat.js
+++ b/web/chat.js
@@ -8,10 +8,22 @@ const micChatBtn = document.getElementById('mic-chat');
 
 const MAX_TITLE_LENGTH = 100;
 const RECENT_FILES = 1;
+const LLM_EXPLICIT_STATUS_KEY = 'llmAssistantStatusProbe';
 
 // Cache of the last Chat.md content we rendered from. renderMessages skips
 // work when the file's content hasn't changed.
 let lastChatText = null;
+let llmStatusProbeScheduled = false;
+let llmAssistantState = {
+    available: false,
+    loading: false,
+    error: '',
+    model: '',
+    action: null,
+    contexts: [],
+    confirmed: false,
+    draft: null,
+};
 
 function updateChatActionButton() {
     if (!sendChatBtn || !micChatBtn) return;
@@ -197,6 +209,7 @@ async function openChat() {
     }
     isChat = true;
     await renderMessages();
+    updateAssistantPanel();
     scrollToBottom();
 }
 
@@ -212,6 +225,7 @@ async function openChatModal() {
 
     chatInput.focus();
     await renderMessages();
+    updateAssistantPanel();
     scrollToBottom();
 }
 
@@ -224,6 +238,7 @@ function closeChatModal() {
         if (sendChatBtn) sendChatBtn.style.display = 'none';
         if (micChatBtn) micChatBtn.style.display = 'none';
     }
+    updateAssistantPanel();
 }
 
 async function toggleChatModal() {
@@ -387,6 +402,9 @@ async function toggleChatMessage(timestamp, text, done) {
 }
 
 function initChat() {
+    ensureAssistantPanel();
+    scheduleLLMStatusCheck();
+    wireAssistantSelectionUpdates();
     chatInput.addEventListener('keydown', async function (e) {
         if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
             e.preventDefault();
@@ -394,6 +412,345 @@ function initChat() {
             autoResize();
         }
     });
+}
+
+function shouldProbeLLMStatus() {
+    const explicitApiUrl = localStorage.getItem('apiUrl') !== null;
+    const explicitLLMProbe = localStorage.getItem(LLM_EXPLICIT_STATUS_KEY) === '1';
+    const linkedServerEvidence = typeof hasLastServerOk === 'function' && hasLastServerOk();
+    return explicitApiUrl || explicitLLMProbe || linkedServerEvidence;
+}
+
+function scheduleLLMStatusCheck() {
+    if (llmStatusProbeScheduled) return;
+    llmStatusProbeScheduled = true;
+    ensureAssistantPanel();
+    updateAssistantPanel();
+    if (!shouldProbeLLMStatus()) return;
+    setTimeout(refreshLLMStatus, 120);
+}
+
+async function refreshLLMStatus() {
+    llmAssistantState.loading = true;
+    llmAssistantState.error = '';
+    updateAssistantPanel();
+
+    const {json, error} = await post('llmStatus', {});
+    llmAssistantState.loading = false;
+
+    if (error || !json) {
+        llmAssistantState.available = false;
+        llmAssistantState.model = '';
+        llmAssistantState.error = 'Assistant unavailable';
+        updateAssistantPanel();
+        return;
+    }
+
+    llmAssistantState.available = json.available === true;
+    llmAssistantState.model = json.model || '';
+    llmAssistantState.error = llmAssistantState.available ? '' : 'Assistant unavailable';
+    updateAssistantPanel();
+}
+
+function ensureAssistantPanel() {
+    if (document.getElementById('chat-assistant-panel')) return;
+    const inputWrap = document.getElementById('chat-input-wrap');
+    if (!inputWrap) return;
+
+    const panel = document.createElement('div');
+    panel.id = 'chat-assistant-panel';
+    panel.className = 'chat-assistant-panel';
+    panel.dataset.testid = 'assistant-panel';
+    panel.dataset.available = 'false';
+    panel.innerHTML = `
+        <div class="assistant-head">
+            <div class="assistant-identity">
+                <span class="assistant-orb" aria-hidden="true"></span>
+                <span class="assistant-title">Assistant</span>
+            </div>
+            <span class="assistant-status" data-testid="assistant-status"></span>
+        </div>
+        <div class="assistant-toolbar">
+            <button type="button" class="assistant-action" data-assistant-source="selected-chat" data-testid="assistant-action-selected">Selection</button>
+            <button type="button" class="assistant-action" data-assistant-source="current-file" data-testid="assistant-action-current-file">Current file</button>
+        </div>
+        <div class="assistant-context" data-testid="assistant-context-label"></div>
+        <label class="assistant-confirm">
+            <input type="checkbox" data-testid="assistant-confirm-context">
+            <span>Send labeled current-file context</span>
+        </label>
+        <div class="assistant-compose">
+            <input class="assistant-prompt" data-testid="assistant-prompt" type="text" placeholder="Ask, summarize, or draft from context">
+            <button type="button" class="assistant-send" data-testid="assistant-send">Ask</button>
+        </div>
+        <div class="assistant-error" data-testid="assistant-error"></div>
+        <div class="assistant-draft" data-testid="assistant-draft" hidden>
+            <div class="assistant-draft-header">
+                <span>Draft</span>
+                <span class="assistant-draft-model"></span>
+            </div>
+            <pre class="assistant-draft-text"></pre>
+            <div class="assistant-draft-actions">
+                <button type="button" data-testid="assistant-copy">Copy</button>
+                <button type="button" data-testid="assistant-insert-current">Insert</button>
+                <button type="button" data-testid="assistant-append-chat">Append</button>
+                <button type="button" data-testid="assistant-discard">Discard</button>
+            </div>
+        </div>
+    `;
+    chatContainer.insertBefore(panel, inputWrap);
+
+    panel.querySelector('[data-assistant-source="selected-chat"]').addEventListener('click', () => {
+        selectAssistantContext('selected-chat');
+    });
+    panel.querySelector('[data-assistant-source="current-file"]').addEventListener('click', () => {
+        selectAssistantContext('current-file');
+    });
+    panel.querySelector('[data-testid="assistant-confirm-context"]').addEventListener('change', event => {
+        llmAssistantState.confirmed = event.target.checked;
+        updateAssistantPanel();
+    });
+    panel.querySelector('[data-testid="assistant-send"]').addEventListener('click', sendAssistantRequest);
+    panel.querySelector('[data-testid="assistant-copy"]').addEventListener('click', copyAssistantDraft);
+    panel.querySelector('[data-testid="assistant-insert-current"]').addEventListener('click', insertAssistantDraftIntoCurrentFile);
+    panel.querySelector('[data-testid="assistant-append-chat"]').addEventListener('click', appendAssistantDraftToChat);
+    panel.querySelector('[data-testid="assistant-discard"]').addEventListener('click', discardAssistantDraft);
+}
+
+function wireAssistantSelectionUpdates() {
+    if (chat.dataset.assistantSelectionWired === 'true') return;
+    chat.dataset.assistantSelectionWired = 'true';
+    chat.addEventListener('click', event => {
+        const message = event.target.closest('.message');
+        if (!message || event.target.closest('.message-actions') || event.target.closest('.complete-btn')) return;
+        if (isMetaKey(event) || event.shiftKey) return;
+        chat.querySelectorAll('.message.selected').forEach(el => {
+            if (el !== message) el.classList.remove('selected');
+        });
+        message.classList.add('selected');
+        updateAssistantPanel();
+    });
+    ['click', 'mouseup', 'keyup'].forEach(eventName => {
+        chat.addEventListener(eventName, () => setTimeout(updateAssistantPanel, 0));
+    });
+    const observer = new MutationObserver(() => updateAssistantPanel());
+    observer.observe(chat, {subtree: true, attributes: true, attributeFilter: ['class']});
+}
+
+function getSelectedChatTexts() {
+    return Array.from(chat.querySelectorAll('.message.selected .message-content'))
+        .map(el => el.textContent.trim())
+        .filter(Boolean);
+}
+
+function getCurrentFileAssistantContext() {
+    if (!currentEditor || !currentEditor.path || currentEditor.path === CHAT_PATH) return null;
+    if (typeof currentEditor.getValue !== 'function') return null;
+    return {
+        source: 'current-file',
+        label: `Current file: ${currentEditor.path}`,
+        path: currentEditor.path,
+        text: currentEditor.getValue(),
+    };
+}
+
+function selectAssistantContext(source) {
+    if (!llmAssistantState.available) return;
+    if (source === 'selected-chat') {
+        const texts = getSelectedChatTexts();
+        if (texts.length === 0) return;
+        llmAssistantState.action = 'summarize';
+        llmAssistantState.contexts = [{
+            source: 'selected-chat',
+            label: 'Selected chat entries',
+            text: texts.join('\n\n'),
+        }];
+        llmAssistantState.confirmed = true;
+    } else if (source === 'current-file') {
+        const context = getCurrentFileAssistantContext();
+        if (!context) return;
+        llmAssistantState.action = 'ask';
+        llmAssistantState.contexts = [context];
+        llmAssistantState.confirmed = false;
+    }
+    updateAssistantPanel();
+}
+
+function reconcileAssistantContext(selectedTexts, currentFileContext) {
+    const firstContext = llmAssistantState.contexts[0];
+    if (!firstContext) return;
+
+    const selectedChatGone = firstContext.source === 'selected-chat' && selectedTexts.length === 0;
+    const currentFileGone = firstContext.source === 'current-file' && (
+        !currentFileContext || currentFileContext.path !== firstContext.path
+    );
+    if (!selectedChatGone && !currentFileGone) return;
+
+    llmAssistantState.action = null;
+    llmAssistantState.contexts = [];
+    llmAssistantState.confirmed = false;
+}
+
+function updateAssistantPanel() {
+    ensureAssistantPanel();
+    const panel = document.getElementById('chat-assistant-panel');
+    if (!panel) return;
+
+    const selectedTexts = getSelectedChatTexts();
+    const currentFileContext = getCurrentFileAssistantContext();
+    reconcileAssistantContext(selectedTexts, currentFileContext);
+    const selectedBtn = panel.querySelector('[data-testid="assistant-action-selected"]');
+    const currentFileBtn = panel.querySelector('[data-testid="assistant-action-current-file"]');
+    const sendBtn = panel.querySelector('[data-testid="assistant-send"]');
+    const confirmWrap = panel.querySelector('.assistant-confirm');
+    const confirmInput = panel.querySelector('[data-testid="assistant-confirm-context"]');
+    const statusEl = panel.querySelector('[data-testid="assistant-status"]');
+    const contextEl = panel.querySelector('[data-testid="assistant-context-label"]');
+    const errorEl = panel.querySelector('[data-testid="assistant-error"]');
+    const draftEl = panel.querySelector('[data-testid="assistant-draft"]');
+    const draftText = panel.querySelector('.assistant-draft-text');
+    const draftModel = panel.querySelector('.assistant-draft-model');
+    const insertBtn = panel.querySelector('[data-testid="assistant-insert-current"]');
+
+    panel.dataset.available = llmAssistantState.available ? 'true' : 'false';
+    panel.setAttribute('aria-busy', llmAssistantState.loading ? 'true' : 'false');
+    panel.classList.toggle('is-loading', llmAssistantState.loading);
+    panel.classList.toggle('is-unavailable', !llmAssistantState.available);
+
+    selectedBtn.disabled = !llmAssistantState.available || selectedTexts.length === 0 || llmAssistantState.loading;
+    currentFileBtn.disabled = !llmAssistantState.available || !currentFileContext || llmAssistantState.loading;
+    insertBtn.disabled = !currentFileContext;
+
+    selectedBtn.classList.toggle('active', llmAssistantState.contexts[0]?.source === 'selected-chat');
+    currentFileBtn.classList.toggle('active', llmAssistantState.contexts[0]?.source === 'current-file');
+    selectedBtn.setAttribute('aria-pressed', llmAssistantState.contexts[0]?.source === 'selected-chat' ? 'true' : 'false');
+    currentFileBtn.setAttribute('aria-pressed', llmAssistantState.contexts[0]?.source === 'current-file' ? 'true' : 'false');
+
+    statusEl.textContent = llmAssistantState.loading
+        ? 'Checking'
+        : llmAssistantState.available
+            ? (llmAssistantState.model || 'Available')
+            : 'Unavailable';
+
+    const firstContext = llmAssistantState.contexts[0];
+    if (firstContext) {
+        contextEl.textContent = firstContext.source === 'selected-chat'
+            ? `${firstContext.label}: ${selectedTexts.length} item${selectedTexts.length === 1 ? '' : 's'}`
+            : firstContext.label;
+    } else if (currentFileContext) {
+        contextEl.textContent = `Current file available: ${currentFileContext.path}`;
+    } else {
+        contextEl.textContent = 'Select chat entries or open a note';
+    }
+
+    const needsCurrentFileConfirmation = firstContext?.source === 'current-file';
+    confirmWrap.style.display = needsCurrentFileConfirmation ? 'flex' : 'none';
+    confirmInput.checked = needsCurrentFileConfirmation && llmAssistantState.confirmed;
+
+    const hasContext = llmAssistantState.contexts.length > 0;
+    sendBtn.disabled = !llmAssistantState.available
+        || llmAssistantState.loading
+        || !hasContext
+        || (needsCurrentFileConfirmation && !llmAssistantState.confirmed);
+
+    errorEl.textContent = llmAssistantState.error || '';
+    draftEl.hidden = !llmAssistantState.draft;
+    draftText.textContent = llmAssistantState.draft?.text || '';
+    draftModel.textContent = llmAssistantState.draft?.model || '';
+}
+
+async function sendAssistantRequest() {
+    if (!llmAssistantState.available || llmAssistantState.loading || llmAssistantState.contexts.length === 0) return;
+    const firstContext = llmAssistantState.contexts[0];
+    if (firstContext.source === 'current-file' && !llmAssistantState.confirmed) return;
+
+    const panel = document.getElementById('chat-assistant-panel');
+    const promptInput = panel.querySelector('[data-testid="assistant-prompt"]');
+    const prompt = promptInput.value.trim()
+        || (firstContext.source === 'selected-chat' ? 'Summarize the selected chat entries.' : 'Help with the current file.');
+
+    llmAssistantState.loading = true;
+    llmAssistantState.error = '';
+    updateAssistantPanel();
+
+    const payload = {
+        action: llmAssistantState.action || 'ask',
+        prompt,
+        contexts: llmAssistantState.contexts.map(context => ({
+            source: context.source,
+            label: context.label,
+            path: context.path,
+            text: context.text,
+        })),
+        clientRequestId: `web-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    };
+
+    const {json, error} = await post('llmChat', payload);
+    llmAssistantState.loading = false;
+
+    if (error || !json || json.status === 'error') {
+        llmAssistantState.error = json?.message || error || 'Assistant request failed';
+        updateAssistantPanel();
+        return;
+    }
+
+    llmAssistantState.draft = {
+        text: json.text || '',
+        model: json.model || llmAssistantState.model || '',
+        requestId: json.requestId || '',
+    };
+    updateAssistantPanel();
+}
+
+async function copyAssistantDraft() {
+    const text = llmAssistantState.draft?.text;
+    if (!text) return;
+    try {
+        await navigator.clipboard.writeText(text);
+    } catch (err) {
+        logError('Failed to copy assistant draft:', err);
+    }
+}
+
+async function insertAssistantDraftIntoCurrentFile() {
+    const text = llmAssistantState.draft?.text;
+    const context = getCurrentFileAssistantContext();
+    if (!text || !context) return;
+    currentEditor.replaceSelection(`${text}\n`);
+    if (typeof syncCurrentFile === 'function') {
+        await syncCurrentFile(true);
+    }
+    discardAssistantDraft();
+}
+
+function formatAssistantChatEntry(text) {
+    const now = new Date();
+    const timestamp = now.toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+    const lines = String(text || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+    const firstLine = (lines[0] || 'Assistant response').trim() || 'Assistant response';
+    const continuation = lines.map(line => `  ${line}`).join('\n');
+    return `\n- [ ] \`${timestamp}\` AI: ${firstLine}\n${continuation}\n`;
+}
+
+async function appendAssistantDraftToChat() {
+    const text = llmAssistantState.draft?.text;
+    if (!text) return;
+    await writeAtEnd(CHAT_PATH, formatAssistantChatEntry(text));
+    chatIsClean = false;
+    lastChatText = null;
+    discardAssistantDraft();
+    await renderMessages();
+    scrollToBottom();
+}
+
+function discardAssistantDraft() {
+    llmAssistantState.draft = null;
+    llmAssistantState.error = '';
+    updateAssistantPanel();
 }
 
 function scrollToBottom() {
@@ -1053,4 +1410,5 @@ async function renderMessages() {
     `).join('');
 
     attachEventListeners();
+    updateAssistantPanel();
 }

--- a/web/editor.js
+++ b/web/editor.js
@@ -29,6 +29,14 @@ function initEditor(el) {
         lineNumbers: false,
         extraKeys: {
             // 'Shift-Space': 'autocomplete',
+            'Cmd-K': () => {
+                document.getElementById('search-input').value = '';
+                searchModal.open();
+            },
+            'Ctrl-K': () => {
+                document.getElementById('search-input').value = '';
+                searchModal.open();
+            },
             'Cmd-[': false, 'Cmd-]': false,
             // Mac's default delWrappedLineLeft is a no-op at column 0, so
             // Cmd-Backspace gets stuck at the line start instead of joining

--- a/web/index.html
+++ b/web/index.html
@@ -10,45 +10,45 @@
     <link rel="icon" href="favicon.ico" sizes="48x48">
     <link rel="icon" href="favicon.svg" sizes="any" type="image/svg+xml">
     <link rel="manifest" href="manifest.json">
-    <link href="app.css?v=" rel="stylesheet">
-    <link href="lib/normalize.css?v=" rel="stylesheet">
-    <link href="lib/sidebar.css?v=" rel="stylesheet">
-    <link href="lib/codemirror.css?v=" rel="stylesheet">
-    <link href="lib/hypermd.css?v=" rel="stylesheet">
-    <link href="lib/theme-brutal.css?v=" rel="stylesheet">
-    <link href="lib/theme-brutal-dark.css?v=" rel="stylesheet">
-    <link href="chat.css?v=" rel="stylesheet">
-    <link href="lib/latex/katex.min.css?v=" rel="stylesheet">
-    <script src="lib/latex/katex.min.js?v="></script>
-    <script src="lib/sidebar.js?v="></script>
-    <script src="lib/codemirror.js?v="></script>
-    <script src="lib/core.js?v="></script>
-    <script src="lib/markdown.js?v="></script>
-    <script src="lib/hypermd.js?v="></script>
-    <script src="lib/keymap.js?v="></script>
-    <script src="lib/click.js?v="></script>
-    <script src="lib/hide-token.js?v="></script>
-    <script src="lib/fold.js?v="></script>
-    <script src="lib/fold-image.js?v="></script>
-    <script src="lib/fold-link.js?v="></script>
-    <script src="lib/fold-code.js?v="></script>
-    <script src="lib/latex/fold-math.js?v="></script>
-    <script src="lib/hypermd-mermaid.js?v="></script>
-    <script src="lib/table.js?v="></script>
-    <script src="lib/autocomplete-link.js?v="></script>
-    <script src="lib/show-hint.js?v="></script>
-    <script src="lib/autoscroll.js?v="></script>
-    <script src="lib/codemirror-go.js?v="></script>
-    <script src="lib/codemirror-python.js?v="></script>
-    <script src="lib/codemirror-javascript.js?v="></script>
-    <script src="lib/codemirror-php.js?v="></script>
-    <script src="lib/codemirror-shell.js?v="></script>
-    <script src="lib/similarity.js?v="></script>
-    <script src="lib/emoji.js?v="></script>
-    <script src="lib/fs.js?v="></script>
-    <script src="lib/md.js?v="></script>
-    <script src="welcome.js?v="></script>
-    <script src="files.js?v="></script>
+    <link href="app.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="lib/normalize.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="lib/sidebar.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="lib/codemirror.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="lib/hypermd.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="lib/theme-brutal.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="lib/theme-brutal-dark.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="chat.css?v=liquid-glass-2" rel="stylesheet">
+    <link href="lib/latex/katex.min.css?v=liquid-glass-2" rel="stylesheet">
+    <script src="lib/latex/katex.min.js?v=liquid-glass-2"></script>
+    <script src="lib/sidebar.js?v=liquid-glass-2"></script>
+    <script src="lib/codemirror.js?v=liquid-glass-2"></script>
+    <script src="lib/core.js?v=liquid-glass-2"></script>
+    <script src="lib/markdown.js?v=liquid-glass-2"></script>
+    <script src="lib/hypermd.js?v=liquid-glass-2"></script>
+    <script src="lib/keymap.js?v=liquid-glass-2"></script>
+    <script src="lib/click.js?v=liquid-glass-2"></script>
+    <script src="lib/hide-token.js?v=liquid-glass-2"></script>
+    <script src="lib/fold.js?v=liquid-glass-2"></script>
+    <script src="lib/fold-image.js?v=liquid-glass-2"></script>
+    <script src="lib/fold-link.js?v=liquid-glass-2"></script>
+    <script src="lib/fold-code.js?v=liquid-glass-2"></script>
+    <script src="lib/latex/fold-math.js?v=liquid-glass-2"></script>
+    <script src="lib/hypermd-mermaid.js?v=liquid-glass-2"></script>
+    <script src="lib/table.js?v=liquid-glass-2"></script>
+    <script src="lib/autocomplete-link.js?v=liquid-glass-2"></script>
+    <script src="lib/show-hint.js?v=liquid-glass-2"></script>
+    <script src="lib/autoscroll.js?v=liquid-glass-2"></script>
+    <script src="lib/codemirror-go.js?v=liquid-glass-2"></script>
+    <script src="lib/codemirror-python.js?v=liquid-glass-2"></script>
+    <script src="lib/codemirror-javascript.js?v=liquid-glass-2"></script>
+    <script src="lib/codemirror-php.js?v=liquid-glass-2"></script>
+    <script src="lib/codemirror-shell.js?v=liquid-glass-2"></script>
+    <script src="lib/similarity.js?v=liquid-glass-2"></script>
+    <script src="lib/emoji.js?v=liquid-glass-2"></script>
+    <script src="lib/fs.js?v=liquid-glass-2"></script>
+    <script src="lib/md.js?v=liquid-glass-2"></script>
+    <script src="welcome.js?v=liquid-glass-2"></script>
+    <script src="files.js?v=liquid-glass-2"></script>
     <!-- mermaid.min.js is lazy-loaded on first ```mermaid encounter -->
 </head>
 <body>
@@ -155,16 +155,16 @@
     </form>
     <ul id="move-results"></ul>
 </div>
-<script src="editor.js?v="></script>
-<script src="app.js?v="></script>
-<script src="chat.js?v="></script>
-<script src="modals.js?v="></script>
+<script src="editor.js?v=liquid-glass-2"></script>
+<script src="app.js?v=liquid-glass-2"></script>
+<script src="chat.js?v=liquid-glass-2"></script>
+<script src="modals.js?v=liquid-glass-2"></script>
 <script>
-    window.COMMIT_HASH = '?v=';
+    window.COMMIT_HASH = '?v=liquid-glass-2';
     log('Current version:', window.COMMIT_HASH);
 
     // Allow offline mode.
-    navigator.serviceWorker?.register('offline.js?v=')
+    navigator.serviceWorker?.register('offline.js?v=liquid-glass-2')
         .then(() => log('Service Worker registered'))
         .catch(() => logError('Service Worker registration failed'));
 

--- a/web/lib/sidebar.css
+++ b/web/lib/sidebar.css
@@ -19,11 +19,12 @@
 	overflow:hidden;
 	text-overflow: ellipsis;
 
-	padding: 2px 4px;
+	padding: 5px 8px;
 	cursor: pointer;
 	display: flex;
 	align-items: center;
-	border-radius: 5px;
+	border-radius: var(--radius-control, 12px);
+	border: 1px solid transparent;
 
 	-webkit-touch-callout: none;
 	-webkit-user-select: none;
@@ -35,10 +36,12 @@
 	text-align: left;
 
 	font-size: 1.1em;
+	transition: background-color var(--transition-fast, 150ms ease), border-color var(--transition-fast, 150ms ease), color var(--transition-fast, 150ms ease), box-shadow var(--transition-fast, 150ms ease);
 }
 
 .tree-container li span.tree-item:hover{
-	background-color: var(--col-bg-active);
+	background: color-mix(in srgb, var(--col-bg-active) 72%, transparent);
+	border-color: var(--surface-border, transparent);
 }
 
 .tree-container li span.tree-mod_icon {
@@ -76,12 +79,23 @@
 	background-color: inherit;
 }
 
-.tree-container span.tree-item.tree-leaf.selected {
-	background-color: var(--col-bg-active);
+.tree-container span.tree-item.selected {
+	background:
+		linear-gradient(135deg,
+			color-mix(in srgb, var(--surface-highlight, #fff) 42%, transparent),
+			color-mix(in srgb, var(--col-bg-active) 70%, transparent));
+	border-color: color-mix(in srgb, var(--color-neo-orange, #e8912d) 28%, var(--surface-border, transparent));
+	color: var(--col-tx);
+	box-shadow:
+		inset 0 1px 0 var(--surface-highlight, transparent),
+		0 5px 14px color-mix(in srgb, var(--col-tx) 7%, transparent);
 }
 
-.tree-container span.tree-item.tree-leaf.selected:hover {
-	background-color: var(--col-bg-active);
+.tree-container span.tree-item.selected:hover {
+	background:
+		linear-gradient(135deg,
+			color-mix(in srgb, var(--surface-highlight, #fff) 50%, transparent),
+			color-mix(in srgb, var(--col-bg-active) 78%, transparent));
 }
 
 /*Drag'n'drop styles*/
@@ -105,10 +119,10 @@
 }
 
 .tree-drop_target {
-	background-color: var(--col-bg-active);
+	background: color-mix(in srgb, var(--color-neo-orange, #e8912d) 12%, var(--col-bg-active));
 	color: var(--col-link);
 	/*border: 2px solid var(--color-border) !important;*/
-	border-radius: 5px;
+	border-radius: var(--radius-control, 12px);
 }
 
 .tree-item[draggable="true"] {
@@ -146,6 +160,7 @@
 	flex: 1;
 	overflow-y: auto;
 	overflow-x: hidden;
+	padding: 2px 0 8px;
 }
 
 #sidebar ul {
@@ -184,9 +199,10 @@
 }
 
 .resize:hover::after {
-	width: 5px;
+	width: 4px;
 	right: 4px;
-	background: var(--col-border);
+	border-radius: var(--radius-pill, 999px);
+	background: color-mix(in srgb, var(--color-neo-orange, #e8912d) 42%, var(--surface-border, var(--col-border)));
 }
 
 #close-sidebar {
@@ -205,11 +221,13 @@
 
 .sidebar-ctx-menu {
 	position: fixed;
-	background: var(--col-bg, #fff);
+	background: var(--surface-glass-strong, var(--col-bg, #fff));
 	color: var(--col-tx, #000);
-	border: 1px solid var(--col-border, rgba(0, 0, 0, 0.15));
-	border-radius: 6px;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+	border: 1px solid var(--surface-border, rgba(0, 0, 0, 0.15));
+	border-radius: var(--radius-control, 12px);
+	box-shadow: var(--surface-shadow-soft, 0 4px 12px rgba(0, 0, 0, 0.12));
+	backdrop-filter: blur(var(--blur-control, 14px)) saturate(1.2);
+	-webkit-backdrop-filter: blur(var(--blur-control, 14px)) saturate(1.2);
 	padding: 4px 0;
 	z-index: 10000;
 	min-width: 140px;
@@ -220,8 +238,10 @@
 .sidebar-ctx-menu-item {
 	padding: 6px 12px;
 	cursor: pointer;
+	border-radius: 8px;
+	margin: 1px 4px;
 }
 
 .sidebar-ctx-menu-item:hover {
-	background: color-mix(in srgb, var(--col-tx, #000) 10%, transparent);
+	background: color-mix(in srgb, var(--col-bg-active) 80%, transparent);
 }

--- a/web/lib/theme-brutal-dark.css
+++ b/web/lib/theme-brutal-dark.css
@@ -372,32 +372,47 @@
 
 
 .tree-container li span.tree-item {
-    border-radius: 0 !important;
+    border-radius: var(--radius-control, 12px) !important;
 }
 
 .tree-container li span.tree-item:hover {
-    background-color: var(--color-neo-orange) !important;
-    color: #1F1D1A !important;
+    background: color-mix(in srgb, var(--col-bg-active) 72%, transparent) !important;
+    border-color: var(--surface-border, transparent) !important;
+    color: var(--col-tx) !important;
 }
 .tree-container li span.tree-item:hover .tree-mod_icon svg {
-    stroke: #1F1D1A !important;
+    stroke: var(--col-tx) !important;
 }
 
-.tree-container span.tree-item.tree-leaf.selected,
-.tree-container span.tree-item.tree-leaf.selected:hover {
-    background-color: var(--color-neo-blue) !important;
-    color: #E8E3D8 !important;
+.tree-container span.tree-item.selected {
+    background:
+        linear-gradient(135deg,
+            color-mix(in srgb, var(--surface-highlight, #fff) 42%, transparent),
+            color-mix(in srgb, var(--col-bg-active) 70%, transparent)) !important;
+    border-color: color-mix(in srgb, var(--color-neo-orange) 28%, var(--surface-border, transparent)) !important;
+    color: var(--col-tx) !important;
+    box-shadow:
+        inset 0 1px 0 var(--surface-highlight, transparent),
+        0 5px 14px color-mix(in srgb, var(--col-tx) 7%, transparent) !important;
 }
-.tree-container span.tree-item.tree-leaf.selected .tree-mod_icon svg,
-.tree-container span.tree-item.tree-leaf.selected:hover .tree-mod_icon svg {
-    stroke: #E8E3D8 !important;
+
+.tree-container span.tree-item.selected:hover {
+    background:
+        linear-gradient(135deg,
+            color-mix(in srgb, var(--surface-highlight, #fff) 50%, transparent),
+            color-mix(in srgb, var(--col-bg-active) 78%, transparent)) !important;
+}
+.tree-container span.tree-item.selected .tree-mod_icon svg,
+.tree-container span.tree-item.selected:hover .tree-mod_icon svg {
+    stroke: var(--col-tx) !important;
 }
 
 #search-results .focused,
 #move-results .focused {
-    background-color: var(--color-neo-orange) !important;
-    color: #1F1D1A !important;
-    border-radius: 0 !important;
+    background: color-mix(in srgb, var(--color-neo-orange) 8%, var(--col-bg-active)) !important;
+    color: var(--col-tx) !important;
+    border-radius: var(--radius-control, 12px) !important;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-neo-orange) 22%, transparent) !important;
 }
 
 .message {
@@ -449,18 +464,25 @@
     color: var(--color-neo-orange) !important;
 }
 
-#search, #move,
+#search, #move {
+    border-radius: var(--radius-panel, 24px) !important;
+}
+
 #search-input, #move-input,
 .message-content,
 .message-actions,
 .CodeMirror-hints,
 .CodeMirror-hint,
 .sidebar-ctx-menu {
-    border-radius: 0 !important;
+    border-radius: var(--radius-control, 12px) !important;
+}
+
+#nav-buttons {
+    border-radius: var(--radius-pill, 999px) !important;
 }
 
 #chat-container.modal {
-    border-radius: 7px !important;
+    border-radius: var(--radius-panel, 24px) !important;
 }
 #chat-input {
     border-radius: 6px !important;

--- a/web/lib/theme-brutal.css
+++ b/web/lib/theme-brutal.css
@@ -390,32 +390,47 @@
 }
 
 .tree-container li span.tree-item {
-    border-radius: 0 !important;
+    border-radius: var(--radius-control, 12px) !important;
 }
 
 .tree-container li span.tree-item:hover {
-    background-color: var(--color-neo-orange) !important;
-    color: #1A1A1A !important;
+    background: color-mix(in srgb, var(--col-bg-active) 72%, transparent) !important;
+    border-color: var(--surface-border, transparent) !important;
+    color: var(--col-tx) !important;
 }
 .tree-container li span.tree-item:hover .tree-mod_icon svg {
-    stroke: #1A1A1A !important;
+    stroke: var(--col-tx) !important;
 }
 
-.tree-container span.tree-item.tree-leaf.selected,
-.tree-container span.tree-item.tree-leaf.selected:hover {
-    background-color: var(--color-neo-blue) !important;
-    color: #FFF !important;
+.tree-container span.tree-item.selected {
+    background:
+        linear-gradient(135deg,
+            color-mix(in srgb, var(--surface-highlight, #fff) 42%, transparent),
+            color-mix(in srgb, var(--col-bg-active) 70%, transparent)) !important;
+    border-color: color-mix(in srgb, var(--color-neo-orange) 28%, var(--surface-border, transparent)) !important;
+    color: var(--col-tx) !important;
+    box-shadow:
+        inset 0 1px 0 var(--surface-highlight, transparent),
+        0 5px 14px color-mix(in srgb, var(--col-tx) 7%, transparent) !important;
 }
-.tree-container span.tree-item.tree-leaf.selected .tree-mod_icon svg,
-.tree-container span.tree-item.tree-leaf.selected:hover .tree-mod_icon svg {
-    stroke: #FFF !important;
+
+.tree-container span.tree-item.selected:hover {
+    background:
+        linear-gradient(135deg,
+            color-mix(in srgb, var(--surface-highlight, #fff) 50%, transparent),
+            color-mix(in srgb, var(--col-bg-active) 78%, transparent)) !important;
+}
+.tree-container span.tree-item.selected .tree-mod_icon svg,
+.tree-container span.tree-item.selected:hover .tree-mod_icon svg {
+    stroke: var(--col-tx) !important;
 }
 
 #search-results .focused,
 #move-results .focused {
-    background-color: var(--color-neo-orange) !important;
-    color: #1A1A1A !important;
-    border-radius: 0 !important;
+    background: color-mix(in srgb, var(--color-neo-orange) 8%, var(--col-bg-active)) !important;
+    color: var(--col-tx) !important;
+    border-radius: var(--radius-control, 12px) !important;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-neo-orange) 22%, transparent) !important;
 }
 
 .message {
@@ -475,18 +490,25 @@
     color: var(--color-neo-orange) !important;
 }
 
-#search, #move,
+#search, #move {
+    border-radius: var(--radius-panel, 24px) !important;
+}
+
 #search-input, #move-input,
 .message-content,
 .message-actions,
 .CodeMirror-hints,
 .CodeMirror-hint,
 .sidebar-ctx-menu {
-    border-radius: 0 !important;
+    border-radius: var(--radius-control, 12px) !important;
+}
+
+#nav-buttons {
+    border-radius: var(--radius-pill, 999px) !important;
 }
 
 #chat-container.modal {
-    border-radius: 7px !important;
+    border-radius: var(--radius-panel, 24px) !important;
 }
 #chat-input {
     border-radius: 6px !important;

--- a/web/modals.js
+++ b/web/modals.js
@@ -8,7 +8,7 @@ class SearchModal {
     }
 
     init() {
-        document.getElementById('search').addEventListener('keydown', (event) => {
+        const handleSearchKeydown = (event) => {
             const resultsList = document.getElementById('search-results').querySelectorAll('li');
 
             if (event.key === 'Enter') {
@@ -36,6 +36,20 @@ class SearchModal {
                     currentEditor.focus();
                 }
             }
+        };
+
+        document.getElementById('search').addEventListener('keydown', handleSearchKeydown);
+
+        const searchInput = document.getElementById('search-input');
+        searchInput.addEventListener('input', () => this.search());
+        searchInput.addEventListener('keydown', (event) => {
+            if (!['Enter', 'ArrowDown', 'ArrowUp', 'Escape'].includes(event.key)) return;
+            handleSearchKeydown(event);
+            event.stopPropagation();
+        });
+        document.querySelector('#search form').addEventListener('submit', (event) => {
+            event.preventDefault();
+            this.handleEnterKey();
         });
 
         // Close on outside click
@@ -210,27 +224,44 @@ class SearchModal {
 
         if (buttonElement && this.selectedMsgElement !== null) {
             const rect = buttonElement.getBoundingClientRect();
-            const modalHeight = 300;
+            const viewportWidth = window.innerWidth;
             const viewportHeight = window.innerHeight;
+            const viewportMargin = 12;
             const spaceBelow = viewportHeight - rect.bottom;
             const spaceAbove = rect.top;
 
             // TODO move to css
-            const positionAbove = spaceBelow < modalHeight && spaceAbove > spaceBelow;
             modal.style.position = 'fixed';
-
-            modal.style.left = '50%';
-            modal.style.transform = 'translateX(-50% + 150px)';
             modal.style.width = '320px';
+            modal.style.maxHeight = `calc(100vh - ${viewportMargin * 2}px)`;
+
+            const modalRect = modal.getBoundingClientRect();
+            const modalWidth = modalRect.width;
+            const modalHeight = Math.min(modalRect.height || 320, viewportHeight - viewportMargin * 2);
+            const positionAbove = spaceBelow < modalHeight + 5 && spaceAbove > spaceBelow;
+            const preferredLeft = rect.left + rect.width / 2 - modalWidth / 2;
+            const left = Math.min(
+                Math.max(preferredLeft, viewportMargin),
+                viewportWidth - modalWidth - viewportMargin,
+            );
+            const preferredTop = positionAbove
+                ? rect.top - modalHeight - 5
+                : rect.bottom + 5;
+            const top = Math.min(
+                Math.max(preferredTop, viewportMargin),
+                viewportHeight - modalHeight - viewportMargin,
+            );
+
+            modal.style.left = `${left}px`;
+            modal.style.right = '';
+            modal.style.transform = 'none';
+            modal.style.top = `${top}px`;
+            modal.style.bottom = '';
 
             if (positionAbove) {
-                modal.style.bottom = `${viewportHeight - rect.top + 5}px`;
-                modal.style.top = '';
                 // Reverse the order: results on top, input at bottom
                 modal.classList.add('modal-reversed');
             } else {
-                modal.style.top = `${rect.bottom + 5}px`;
-                modal.style.bottom = '';
                 // Normal order: input on top, results below
                 modal.classList.remove('modal-reversed');
             }
@@ -243,6 +274,7 @@ class SearchModal {
             modal.style.right = '';
             modal.style.transform = 'translate(-50%, 0)';
             modal.style.width = '';
+            modal.style.maxHeight = '';
             modal.classList.remove('modal-reversed');
         }
     }
@@ -407,6 +439,11 @@ class SearchModal {
     }
 
     handleEnterKey() {
+        const inputValue = document.getElementById('search-input').value;
+        if (inputValue !== '') {
+            this.search();
+        }
+
         const resultsList = document.getElementById('search-results').querySelectorAll('li');
         const item = resultsList[this.focusedIndex];
         if (!item) return;


### PR DESCRIPTION
## Summary

This PR adds an optional external LLM assistant to the Files.md chat workflow and refreshes the web UI with a quieter Liquid Glass-inspired visual treatment.

The assistant is disabled unless a self-hosted server configures an OpenAI-compatible provider, so the default local-first/plain Markdown workflow remains unchanged.

## What changed

### External LLM assistant

- Add server-side LLM configuration via environment variables:
  - `LLM_PROVIDER_BASE_URL`
  - `LLM_MODEL`
  - `LLM_API_KEY`
  - request/body/context/rate-limit settings
- Add authenticated API routes:
  - `POST /llmStatus`
  - `POST /llmChat`
- Add an OpenAI-compatible chat completions client.
- Normalize LLM auth errors without exposing provider URL or API key.
- Add request limits for body size, prompt size, context size, response size, per-user/IP rates, user concurrency, and daily quota.
- Keep normal chat capture separate from LLM calls.

### Chat UX

- Add an Assistant panel in Chat.
- Support drafting from selected chat entries.
- Support drafting from the current file with explicit confirmation before sending file context.
- Support copying a draft, inserting it into the current note, or appending it to `Chat.md`.
- Avoid probing LLM status on the default hosted app unless the user has linked an explicit server.

### UI refresh

- Add a floating rounded sidebar.
- Add restrained glass-style surfaces for navigation, toolbar/search/modal/chat controls.
- Preserve Markdown readability and editor density.
- Keep light/dark mode behavior tied to `prefers-color-scheme`.
- Add reduced-motion / lower-transparency fallbacks where relevant.

## Screenshots

### Dark mode

![Dark mode chat assistant](https://raw.githubusercontent.com/LRriver/files.md/pr-assets-external-llm-chat/pr-assets/external-llm-chat/dark-chat-assistant.png)

### Light mode

![Light mode chat assistant](https://raw.githubusercontent.com/LRriver/files.md/pr-assets-external-llm-chat/pr-assets/external-llm-chat/light-chat-assistant.png)

## Validation

- [x] `git diff --check`
- [x] `node --check web/app.js && node --check web/chat.js && node --check web/modals.js && node --check web/editor.js`
- [x] `npm run test -- chat.spec.js --workers=1` — 23 passed
- [x] `npm run test -- editor.spec.js:53 --workers=1` — 1 passed
- [ ] Go tests were not run locally because `go` / `gofmt` were not available in this environment.
- [ ] A live external provider call was not run locally because no real LLM API key was available; browser tests mock the LLM endpoints and verify request boundaries, context handling, and UI flow.

## Notes

- LLM responses are currently non-streaming.
- The assistant only sends explicitly selected chat entries or a confirmed current-file context.
- The API key stays server-side; the frontend only sees availability/model metadata and generated text.
