### PR TITLE
docs: escape semicolon in mermaid sync-flow diagram to fix rendering

### DIFF
--- a/docs/sync-flow.md
+++ b/docs/sync-flow.md
@@ -155,7 +155,7 @@ sequenceDiagram
         S->>L: scan fslog for this user
         S->>S: deletes = DeletesLog(uid, req.serverTime+1)<br/>→ {"foo.md": <ts of A's delete>}<br/>(no suppression: B didn't delete it)
         S-->>B: response.deleted = {"foo.md": <ts>}<br/>response.files = [archive/foo.md, ...]
-        B->>B: for each (path, deletedAt) in response.deleted:<br/>local = getMemFile(path)<br/>if local && local.lastModified ≤ deletedAt:<br/>  await remove(path); removeServerFile(path)
+        B->>B: for each (path, deletedAt) in response.deleted:<br/>local = getMemFile(path)<br/>if local && local.lastModified ≤ deletedAt:<br/>  await remove(path)#59; removeServerFile(path)
         B->>B: write archive/foo.md from response.files
     end
 


### PR DESCRIPTION
before (https://github.com/zakirullin/files.md/blob/0f9ddc503697720dbf9d20ed08ef988a0f010d9c/docs/sync-flow.md)

<img width="1144" height="643" alt="image" src="https://github.com/user-attachments/assets/0ca9f862-22f3-4d55-898f-d582fdb05a59" />

after

<img width="1138" height="539" alt="image" src="https://github.com/user-attachments/assets/10c6980b-0094-4382-b217-6db29bb60e95" />
